### PR TITLE
* Minor changes for succesful builds against .NET3.5

### DIFF
--- a/Mono.TextTemplating/Mono.TextTemplating/CompiledTemplate.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/CompiledTemplate.cs
@@ -88,7 +88,7 @@ namespace Mono.TextTemplating
 				throw new ArgumentException ("Template must have 'Error(string message)' method");
 			}
 
-			var errors = (CompilerErrorCollection) errorProp.GetValue (textTransformation);
+			var errors = (CompilerErrorCollection) errorProp.GetValue (textTransformation,null);
 			errors.Clear ();
 			
 			//set the culture

--- a/Mono.TextTemplating/Mono.TextTemplating/StringUtil.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/StringUtil.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.IO;
+
+namespace Mono.TextTemplating
+{
+	static class StringUtil
+	{
+		public static bool IsNullOrWhiteSpace(string value)
+    	{
+        	if (value == null) return true;
+        	return string.IsNullOrEmpty(value.Trim());
+    	}
+	}
+}

--- a/Mono.TextTemplating/Mono.TextTemplating/StringUtil.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/StringUtil.cs
@@ -1,14 +1,14 @@
-﻿using System;
+using System;
 using System.IO;
 
 namespace Mono.TextTemplating
 {
-	static class StringUtil
+	static class StringUtil	
 	{
 		public static bool IsNullOrWhiteSpace(string value)
-    	{
-        	if (value == null) return true;
-        	return string.IsNullOrEmpty(value.Trim());
-    	}
+		{
+			if (value == null) return true;
+			return string.IsNullOrEmpty(value.Trim());
+		}
 	}
 }

--- a/Mono.TextTemplating/Mono.TextTemplating/StringUtil.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/StringUtil.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Mono.TextTemplating
 {
-	static class StringUtil	
+	static class StringUtil
 	{
 		public static bool IsNullOrWhiteSpace(string value)
 		{

--- a/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
@@ -147,7 +147,7 @@ namespace Mono.TextTemplating
 				var obj = domain.CreateInstanceFromAndUnwrap (type.Assembly.Location, type.FullName, false,
 					BindingFlags.Default, null,
 					new object[] { host, results, templateClassFullName, settings.Culture, references.ToArray () },
-					null, null);
+					null, null,null);
 				return (CompiledTemplate)obj;
 			}
 			return new CompiledTemplate (host, results, templateClassFullName, settings.Culture, references.ToArray ());
@@ -167,7 +167,7 @@ namespace Mono.TextTemplating
 			
 			if (settings.Debug)
 				pars.TempFiles.KeepFiles = true;
-			if (string.IsNullOrWhiteSpace (pars.CompilerOptions))
+			if (StringUtil.IsNullOrWhiteSpace (pars.CompilerOptions))
 				pars.CompilerOptions = "/noconfig";
 			else if (!pars.CompilerOptions.Contains ("/noconfig"))
 				pars.CompilerOptions = "/noconfig " + pars.CompilerOptions;


### PR DESCRIPTION
Trying to use this solution in Unity 5.6 which is still using Mono 2.0. Couldn't find an old dll so applying the minimum of changes to pass the build.