### PR TITLE
Fix parsing of dotnet-t4 command-line options

### DIFF
--- a/dotnet-t4/TextTransform.cs
+++ b/dotnet-t4/TextTransform.cs
@@ -122,7 +122,7 @@ namespace Mono.TextTemplating
 			};
 
 			var remainingArgs = optionSet.Parse (args);
-			remainingArgs = compatOptionSet.Parse (args);
+			remainingArgs = compatOptionSet.Parse (remainingArgs);
 
 			string inputContent = null;
 			if (remainingArgs.Count != 1) {


### PR DESCRIPTION
This PR fixes issue #33 by feeding the tail arguments from the first phase of parsing options to the second phase of parsing deprecated options.

Note that if you apply this PR and test it like this:

    dotnet run -p dotnet-t4 -- -o=- dotnet-t4\test.tt

then `dotnet-t4` will still fail because of issues #29 and #31. To properly test the effects of this PR, apply it together with PR #30 and PR #32 as shown here:

```
git clone https://github.com/mono/t4.git t4
cd t4
git checkout v2.0.1
git pull https://github.com/atifaziz/t4.git issue-29
git pull https://github.com/atifaziz/t4.git issue-31
git pull https://github.com/atifaziz/t4.git issue-33
dotnet run -p dotnet-t4 -- -o=- dotnet-t4\test.tt
```

You should then see the following output:

```
50
blah
```
