### PR TITLE
GH36: Make dotnet-t4 more compat with existing TextTransform templates

### DIFF
--- a/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
@@ -40,6 +40,21 @@ namespace Mono.TextTemplating
 #endif
 		ITextTemplatingEngineHost
 	{
+		static readonly Dictionary<string, string> KnownAssemblies = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase)
+		{
+			{ "System.Core.dll", typeof(System.Linq.Enumerable).Assembly.Location },
+			{ "System.Data.dll", typeof(System.Data.DataTable).Assembly.Location },
+			{ "System.Linq.dll", typeof(System.Linq.Enumerable).Assembly.Location },
+			{ "System.Xml.dll", typeof(System.Xml.XmlAttribute).Assembly.Location },
+			{ "System.Xml.Linq.dll", typeof(System.Xml.Linq.XDocument).Assembly.Location },
+
+			{ "System.Core", typeof(System.Linq.Enumerable).Assembly.Location },
+			{ "System.Data", typeof(System.Data.DataTable).Assembly.Location },
+			{ "System.Linq", typeof(System.Linq.Enumerable).Assembly.Location },
+			{ "System.Xml", typeof(System.Xml.XmlAttribute).Assembly.Location },
+			{ "System.Xml.Linq", typeof(System.Xml.Linq.XDocument).Assembly.Location }
+		};
+
 		//re-usable
 		TemplatingEngine engine;
 		
@@ -60,6 +75,8 @@ namespace Mono.TextTemplating
 		{
 			Refs.Add (typeof (TextTransformation).Assembly.Location);
 			Refs.Add (typeof(Uri).Assembly.Location);
+			Refs.Add (typeof (File).Assembly.Location);
+			Refs.Add (typeof (StringReader).Assembly.Location);
 			Imports.Add ("System");
 		}
 		
@@ -204,6 +221,10 @@ namespace Mono.TextTemplating
 			var assemblyName = new AssemblyName(assemblyReference);
 			if (assemblyName.Version != null)//Load via GAC and return full path
 				return Assembly.Load (assemblyName).Location;
+
+			if (KnownAssemblies.TryGetValue (assemblyReference, out string mappedAssemblyReference)) {
+				return mappedAssemblyReference;
+			}
 
 			if (!assemblyReference.EndsWith (".dll", StringComparison.OrdinalIgnoreCase) && !assemblyReference.EndsWith (".exe", StringComparison.OrdinalIgnoreCase))
 				return assemblyReference + ".dll";

--- a/dotnet-t4/test.hello
+++ b/dotnet-t4/test.hello
@@ -1,2 +1,11 @@
-﻿50
-blah
+﻿File exists: False
+
+Parsed xml: <xml>
+  <hello>
+    <world />
+  </hello>
+</xml>
+
+Root name: xml
+
+Even numbers: 2,4,6,8,10

--- a/dotnet-t4/test.tt
+++ b/dotnet-t4/test.tt
@@ -1,4 +1,33 @@
 <#@ output extension=".hello" #>
-<#@ assembly name="System.Xml" #>
-<#=5*10#>
-blah
+<#@ assembly name="System.Core.dll" #>
+<#@ assembly name="System.Xml.dll" #>
+<#@ assembly name="System.Xml.Linq.dll" #>
+<#
+    // Test System.IO
+   var fileContent = System.IO.File.Exists("C:/temp/test_non_existent_file.txt");
+
+   // Test System.Xml.Linq
+   var xml = System.Xml.Linq.XDocument.Parse("<xml><hello><world /></hello></xml>");
+
+   // Test System.Xml
+   var settings = new System.Xml.XmlReaderSettings();
+   string rootName;
+   using(var reader = System.Xml.XmlReader.Create(new System.IO.StringReader("<xml><hello><world /></hello></xml>"), settings))
+   {
+        rootName = reader.Read() ? reader.Name : string.Empty;
+   }
+
+   // Test System.Linq
+   var even = string.Join(",",
+                System.Linq.Enumerable.Where(
+                System.Linq.Enumerable.Range(1,10),
+                x => x % 2 == 0
+                ));
+#>
+File exists: <#= fileContent #>
+
+Parsed xml: <#= xml #>
+
+Root name: <#= rootName #>
+
+Even numbers: <#= even #>


### PR DESCRIPTION
* Add System.IO by default
* Support known .NET Framework assemblies
* fixes #36

