### PR TITLE
Fix template generation when user name has a space on Windows

### DIFF
--- a/Mono.TextTemplating/Mono.TextTemplating.CodeCompilation/CscCodeCompiler.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating.CodeCompilation/CscCodeCompiler.cs
@@ -124,17 +124,22 @@ namespace Mono.TextTemplating.CodeCompilation
 				}
 
 				foreach (var reference in arguments.AssemblyReferences) {
-					rsp.Write ("\"-r:");
+					rsp.Write ("-r:");
+					rsp.Write ("\"");
 					rsp.Write (ResolveAssembly (runtime, reference));
 					rsp.WriteLine ("\"");
 				}
 
 				rsp.Write ("-out:");
-				rsp.WriteLine (arguments.OutputPath);
+				rsp.Write ("\"");
+				rsp.Write (arguments.OutputPath);
+				rsp.WriteLine ("\"");
 
 				//in older versions of csc, these must come last
 				foreach (var file in arguments.SourceFiles) {
-					rsp.WriteLine (file);
+					rsp.Write ("\"");
+					rsp.Write (file);
+					rsp.WriteLine ("\"");
 				}
 			}
 


### PR DESCRIPTION
On Windows, if username has a space in its name, any kind of template generation is completely broken.

Here is an example with username `Test Space`:
![image](https://user-images.githubusercontent.com/527565/51648814-73016380-1fc5-11e9-924f-35e5483937c7.png)