### PR TITLE
GH35: Fix .NET Tool template debugging

### DIFF
--- a/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
@@ -59,7 +59,6 @@ namespace Mono.TextTemplating
 		TemplatingEngine engine;
 		
 		//per-run variables
-		string inputFile;
 		Encoding encoding;
 
 		//host properties for consumers to access
@@ -69,6 +68,7 @@ namespace Mono.TextTemplating
 		public List<string> IncludePaths { get; } = new List<string> ();
 		public List<string> ReferencePaths { get; } = new List<string> ();
 		public string OutputFile { get; protected set; }
+		public string TemplateFile { get; protected set; }
 		public bool UseRelativeLinePragmas { get; set; }
 		
 		public TemplateGenerator ()
@@ -133,7 +133,7 @@ namespace Mono.TextTemplating
 			encoding = Encoding.UTF8;
 
 			OutputFile = outputFileName;
-			inputFile = inputFileName;
+			TemplateFile = inputFileName;
 			outputContent = Engine.ProcessTemplate (inputContent, this);
 			outputFileName = OutputFile;
 			
@@ -178,8 +178,8 @@ namespace Mono.TextTemplating
 		{
 			Errors.Clear ();
 			encoding = Encoding.UTF8;
-			
-			inputFile = inputFileName;
+
+			TemplateFile = inputFileName;
 			outputContent = Engine.PreprocessTemplate (inputContent, this, className, classNamespace, out language, out references);
 			
 			return !Errors.HasErrors;
@@ -257,7 +257,7 @@ namespace Mono.TextTemplating
 			path = Environment.ExpandEnvironmentVariables (path);
 			if (Path.IsPathRooted (path))
 				return path;
-			var dir = Path.GetDirectoryName (inputFile);
+			var dir = Path.GetDirectoryName (TemplateFile);
 			var test = Path.Combine (dir, path);
 			if (File.Exists (test) || Directory.Exists (test))
 				return test;
@@ -424,9 +424,6 @@ namespace Mono.TextTemplating
 			get { return Imports; }
 		}
 		
-		string ITextTemplatingEngineHost.TemplateFile {
-			get { return inputFile; }
-		}
 		
 		#endregion
 		

--- a/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
@@ -233,7 +233,7 @@ namespace Mono.TextTemplating
 			if (result.Success) {
 				r.TempFiles.AddFile (args.OutputPath, true);
 				if (args.Debug) {
-					r.TempFiles.AddFile (Path.ChangeExtension (args.OutputPath, ".dll"), true);
+					r.TempFiles.AddFile (Path.ChangeExtension (args.OutputPath, ".pdb"), true);
 				}
 				r.PathToAssembly = args.OutputPath;
 			} else if (!r.Errors.HasErrors) {

--- a/dotnet-t4/ToolTemplateGenerator.cs
+++ b/dotnet-t4/ToolTemplateGenerator.cs
@@ -41,6 +41,7 @@ namespace Mono.TextTemplating
 
 		public string PreprocessTemplate (ParsedTemplate pt, string inputFile, string inputContent, string className)
 		{
+			TemplateFile = inputFile;
 			string classNamespace = null;
 			int s = className.LastIndexOf ('.');
 			if (s > 0) {
@@ -53,6 +54,7 @@ namespace Mono.TextTemplating
 
 		public string ProcessTemplate (ParsedTemplate pt, string inputFile, string inputContent, ref string outputFile)
 		{
+			TemplateFile = inputFile;
 			OutputFile = outputFile;
 			using (var compiled = Engine.CompileTemplate (pt, inputContent, this)) {
 				var result = compiled?.Process ();


### PR DESCRIPTION
* Addresses issue with pdb typo (dll)
* Addresses missing template name, resulting in incomplete line directives
* Fixes #35

The Global .NET T4 tool template generator currently doesn't provide the template filename rendering the line directives incomplete and also the pdb incorrect.

Also when debug is specified you currently get the following exception
```diff
- System.ArgumentException: The file name '**redacted**\AppData\Local\Temp\tmp28A6.tmp\GeneratedTextTransformation4e55ec82.dll' was already in the collection.
- Parameter name: fileName
-    at System.CodeDom.Compiler.TempFileCollection.AddFile(String fileName, Boolean keepFile)
-    at Mono.TextTemplating.TemplatingEngine.CompileCode2(IEnumerable`1 references, TemplateSettings settings, CodeCompileUnit ccu) in C:\projects\t4\Mono.TextTemplating\Mono.TextTemplating\TemplatingEngine.cs:line 236
-    at Mono.TextTemplating.TemplatingEngine.CompileTemplateInternal(ParsedTemplate pt, String content, ITextTemplatingEngineHost host) in C:\projects\t4\Mono.TextTemplating\Mono.TextTemplating\TemplatingEngine.cs:line 173
-    at Mono.TextTemplating.TemplatingEngine.CompileTemplate(ParsedTemplate pt, String content, ITextTemplatingEngineHost host) in C:\projects\t4\Mono.TextTemplating\Mono.TextTemplating\TemplatingEngine.cs:line 147
-    at Mono.TextTemplating.ToolTemplateGenerator.ProcessTemplate(ParsedTemplate pt, String inputFile, String inputContent, String& outputFile) in C:\projects\t4\dotnet-t4\ToolTemplateGenerator.cs:line 57
-    at Mono.TextTemplating.TextTransform.MainInternal(String[] args) in C:\projects\t4\dotnet-t4\TextTransform.cs:line 194
-    at Mono.TextTemplating.TextTransform.Main(String[] args) in C:\projects\t4\dotnet-t4\TextTransform.cs:line 42
```
This was due to the fact symbols extension had a typo of `dll` when it should be `pdb`.

This PR corrects both above issues which means this example template

```csharp
<#@ template debug="true" language="C#" #>
<#
    System.Diagnostics.Debugger.Break();
#>
<#="Hello" #>
<#
for(var i = 0;i < 10;i++)
{
    #><#=i #><#
}
#>
```

Now can be debugged and give correct stacktraces

![t4debug](https://user-images.githubusercontent.com/1647294/53052628-81954a80-349f-11e9-88ec-4b795b57d898.gif)
