### PR TITLE
GH43: Fixed relative paths that causes an exception in ResolvePath.

### DIFF
--- a/Mono.TextTemplating.Tests/GenerationTests.cs
+++ b/Mono.TextTemplating.Tests/GenerationTests.cs
@@ -60,6 +60,16 @@ namespace Mono.TextTemplating.Tests
 		}
 
 		[Test]
+		public void IncludeFileThatDoesNotExistTest ()
+		{
+			var gen = new TemplateGenerator ();
+			string tmp = null;
+			gen.ProcessTemplate (null, "<#@ include file=\"none.tt\" #>", ref tmp, out tmp);
+			Assert.IsTrue (gen.Errors.OfType<CompilerError> ().FirstOrDefault ().ErrorText
+				.StartsWith ("Could not read included file 'none.tt'"));
+		}
+
+		[Test]
 		public void Generate ()
 		{
 			string Input = ParsingTests.ParseSample1;

--- a/Mono.TextTemplating.Tests/GenerationTests.cs
+++ b/Mono.TextTemplating.Tests/GenerationTests.cs
@@ -65,7 +65,7 @@ namespace Mono.TextTemplating.Tests
 			var gen = new TemplateGenerator ();
 			string tmp = null;
 			gen.ProcessTemplate (null, "<#@ include file=\"none.tt\" #>", ref tmp, out tmp);
-			Assert.IsTrue (gen.Errors.OfType<CompilerError> ().FirstOrDefault ().ErrorText
+			Assert.IsTrue (gen.Errors.OfType<CompilerError> ().First ().ErrorText
 				.StartsWith ("Could not read included file 'none.tt'"));
 		}
 

--- a/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
@@ -257,7 +257,7 @@ namespace Mono.TextTemplating
 			path = Environment.ExpandEnvironmentVariables (path);
 			if (Path.IsPathRooted (path))
 				return path;
-			var dir = Path.GetDirectoryName (TemplateFile);
+			var dir = Path.GetDirectoryName (TemplateFile) ?? string.Empty;
 			var test = Path.Combine (dir, path);
 			if (File.Exists (test) || Directory.Exists (test))
 				return test;


### PR DESCRIPTION
#43 When a relative path was used in an include directive the ResolvePath would try to get the directory name and would return null that caused path combine to throw an exception.  The solution is to set dir to an empty string when the directory name returns null.  This will prevent the exception and allow using the included paths passed in on the command line.