### PR TITLE
Trim trailing whitespace per editor config

### DIFF
--- a/Mono.TextTemplating.Tests/DummyHost.cs
+++ b/Mono.TextTemplating.Tests/DummyHost.cs
@@ -1,21 +1,21 @@
-// 
+//
 // IncludeFileProviderHost.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,7 +31,7 @@ using Microsoft.VisualStudio.TextTemplating;
 
 namespace Mono.TextTemplating.Tests
 {
-	
+
 	public class DummyHost : ITextTemplatingEngineHost
 	{
 		public readonly Dictionary<string, string> Locations = new Dictionary<string, string> ();
@@ -41,71 +41,71 @@ namespace Mono.TextTemplating.Tests
 		List<string> standardImports = new List<string> ();
 		public readonly CompilerErrorCollection Errors = new CompilerErrorCollection ();
 		public readonly Dictionary<string, Type> DirectiveProcessors = new Dictionary<string, Type> ();
-		
+
 		public virtual object GetHostOption (string optionName)
 		{
 			object o;
 			HostOptions.TryGetValue (optionName, out o);
 			return o;
 		}
-		
+
 		public virtual bool LoadIncludeText (string requestFileName, out string content, out string location)
 		{
 			content = null;
 			return Locations.TryGetValue (requestFileName, out location)
 				&& Contents.TryGetValue (requestFileName, out content);
 		}
-		
+
 		public virtual void LogErrors (CompilerErrorCollection errors)
 		{
 			Errors.AddRange (errors);
 		}
-		
+
 		public virtual AppDomain ProvideTemplatingAppDomain (string content)
 		{
 			return null;
 		}
-		
+
 		public virtual string ResolveAssemblyReference (string assemblyReference)
 		{
 			throw new System.NotImplementedException();
 		}
-		
+
 		public virtual Type ResolveDirectiveProcessor (string processorName)
 		{
 			Type t;
 			DirectiveProcessors.TryGetValue (processorName, out t);
 			return t;
 		}
-		
+
 		public virtual string ResolveParameterValue (string directiveId, string processorName, string parameterName)
 		{
 			throw new System.NotImplementedException();
 		}
-		
+
 		public virtual string ResolvePath (string path)
 		{
 			throw new System.NotImplementedException();
 		}
-		
+
 		public virtual void SetFileExtension (string extension)
 		{
 			throw new System.NotImplementedException();
 		}
-		
+
 		public virtual void SetOutputEncoding (System.Text.Encoding encoding, bool fromOutputDirective)
 		{
 			throw new System.NotImplementedException();
 		}
-		
+
 		public virtual IList<string> StandardAssemblyReferences {
 			get { return standardAssemblyReferences; }
 		}
-		
+
 		public virtual IList<string> StandardImports {
 			get { return standardImports; }
 		}
-		
+
 		public virtual string TemplateFile {
 			get; set;
 		}

--- a/Mono.TextTemplating.Tests/Extensions.cs
+++ b/Mono.TextTemplating.Tests/Extensions.cs
@@ -1,10 +1,10 @@
 //
-// Test.cs
+// Extensions.cs
 //
 // Author:
-//       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
+//       Atif Aziz
 //
-// Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
+// Copyright (c) 2019 Atif Aziz
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,49 +24,41 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
-using System.IO;
-
 namespace Mono.TextTemplating.Tests
 {
-	public static class TemplatingEngineHelper
+	using System;
+	using System.Collections.Generic;
+	using System.IO;
+	using System.Text;
+
+	static class Extensions
 	{
-		/// <summary>
-		/// Cleans CodeDOM generated code so that Windows/Mac and Mono/.NET output can be compared.
-		/// </summary>
-		public static string CleanCodeDom (string input, string newLine, bool dontTrimTrailingWhiteSpace = false)
+		public static IEnumerable<string> SplitIntoLines(this string s)
 		{
-			using (var writer = new StringWriter ()) {
-				using (var reader = new StringReader (input)) {
+			if (s == null) throw new ArgumentNullException (nameof (s));
 
-					bool afterLineDirective = true;
-					bool stripHeader = true;
+			return Iterator ();
 
+			IEnumerable<string> Iterator ()
+			{
+				using (var reader = new StringReader (s)) {
 					string line;
 					while ((line = reader.ReadLine ()) != null) {
-
-						if (stripHeader) {
-							if (line.StartsWith ("//", StringComparison.Ordinal) || StringUtil.IsNullOrWhiteSpace (line))
-								continue;
-							stripHeader = false;
-						}
-
-						if (afterLineDirective) {
-							if (StringUtil.IsNullOrWhiteSpace (line))
-								continue;
-							afterLineDirective = false;
-						}
-
-						if (line.Contains ("#line")) {
-							afterLineDirective = true;
-						}
-
-						writer.Write (dontTrimTrailingWhiteSpace ? line : line.TrimEnd(' ', '\t'));
-						writer.Write (newLine);
+						yield return line;
 					}
 				}
-				return writer.ToString ();
 			}
+		}
+
+		public static string RenormalizeLineEndingsTo(this string s, string eol)
+		{
+			if (s == null) throw new ArgumentNullException (nameof(s));
+
+			var sb = new StringBuilder ();
+			foreach (var line in s.SplitIntoLines ()) {
+				sb.Append (line).Append (eol);
+			}
+			return sb.ToString ();
 		}
 	}
 }

--- a/Mono.TextTemplating.Tests/GenerateIndentedClassCodeTests.cs
+++ b/Mono.TextTemplating.Tests/GenerateIndentedClassCodeTests.cs
@@ -94,10 +94,10 @@ namespace Mono.TextTemplating.Tests
 			}
 		}
 
-		public static string MethodAndFieldGeneratedOutput = 
-@"        
+		public static string MethodAndFieldGeneratedOutput =
+@"
         private bool myField;
-        
+
         private bool MyProperty {
             get {
                 return true;

--- a/Mono.TextTemplating.Tests/GenerationTests.cs
+++ b/Mono.TextTemplating.Tests/GenerationTests.cs
@@ -1,21 +1,21 @@
-// 
+//
 // GenerationTests.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -34,11 +34,11 @@ using System.CodeDom.Compiler;
 
 namespace Mono.TextTemplating.Tests
 {
-	
-	
+
+
 	[TestFixture]
 	public class GenerationTests
-	{	
+	{
 		[Test]
 		public void TemplateGeneratorTest ()
 		{
@@ -76,7 +76,7 @@ namespace Mono.TextTemplating.Tests
 			string Output = OutputSample1;
 			Generate (Input, Output, "\n");
 		}
-		
+
 		[Test]
 		public void GenerateMacNewlines ()
 		{
@@ -84,7 +84,7 @@ namespace Mono.TextTemplating.Tests
 			string MacOutput = OutputSample1.Replace ("\\n", "\\r").Replace ("\n", "\r");;
 			Generate (MacInput, MacOutput, "\r");
 		}
-		
+
 		[Test]
 		public void GenerateWindowsNewlines ()
 		{
@@ -103,7 +103,7 @@ namespace Mono.TextTemplating.Tests
 			TemplateSettings settings = TemplatingEngine.GetSettings (host, pt);
 			Assert.AreEqual (settings.Language, "C#");
 		}
-		
+
 		//NOTE: we set the newline property on the code generator so that the whole files has matching newlines,
 		// in order to match the newlines in the verbatim code blocks
 		void Generate (string input, string expectedOutput, string newline)
@@ -117,9 +117,9 @@ namespace Mono.TextTemplating.Tests
 			expectedOutput = TemplatingEngineHelper.CleanCodeDom (expectedOutput, newline);
 			Assert.AreEqual (expectedOutput, generated);
 		}
-		
+
 		#region Helpers
-		
+
 		string GenerateCode (ITextTemplatingEngineHost host, string content, string name, string generatorNewline)
 		{
 			ParsedTemplate pt = ParsedTemplate.FromText (content, host);
@@ -127,7 +127,7 @@ namespace Mono.TextTemplating.Tests
 				host.LogErrors (pt.Errors);
 				return null;
 			}
-			
+
 			TemplateSettings settings = TemplatingEngine.GetSettings (host, pt);
 			if (name != null)
 				settings.Name = name;
@@ -135,13 +135,13 @@ namespace Mono.TextTemplating.Tests
 				host.LogErrors (pt.Errors);
 				return null;
 			}
-			
+
 			var ccu = TemplatingEngine.GenerateCompileUnit (host, content, pt, settings);
 			if (pt.Errors.HasErrors) {
 				host.LogErrors (pt.Errors);
 				return null;
 			}
-			
+
 			var opts = new System.CodeDom.Compiler.CodeGeneratorOptions ();
 			using (var writer = new System.IO.StringWriter ()) {
 				writer.NewLine = generatorNewline;
@@ -157,55 +157,55 @@ namespace Mono.TextTemplating.Tests
 		public static string OutputSample1 =
 @"
 namespace Microsoft.VisualStudio.TextTemplating {
-    
-    
+
+
     public partial class GeneratedTextTransformation4f504ca0 : global::Microsoft.VisualStudio.TextTemplating.TextTransformation {
-        
-        
+
+
         #line 9 """"
 
 var s = ""baz \\#>"";
 
         #line default
         #line hidden
-        
+
         public override string TransformText() {
             this.GenerationEnvironment = null;
-            
+
             #line 2 """"
             this.Write(""Line One\nLine Two\n"");
-            
+
             #line default
             #line hidden
-            
+
             #line 4 """"
 
 var foo = 5;
 
-            
+
             #line default
             #line hidden
-            
+
             #line 7 """"
             this.Write(""Line Three "");
-            
+
             #line default
             #line hidden
-            
+
             #line 7 """"
             this.Write(global::Microsoft.VisualStudio.TextTemplating.ToStringHelper.ToStringWithCulture( bar ));
-            
+
             #line default
             #line hidden
-            
+
             #line 7 """"
             this.Write(""\nLine Four\n"");
-            
+
             #line default
             #line hidden
             return this.GenerationEnvironment.ToString();
         }
-        
+
         public override void Initialize() {
             base.Initialize();
         }

--- a/Mono.TextTemplating.Tests/GenerationTests.cs
+++ b/Mono.TextTemplating.Tests/GenerationTests.cs
@@ -80,16 +80,16 @@ namespace Mono.TextTemplating.Tests
 		[Test]
 		public void GenerateMacNewlines ()
 		{
-			string MacInput = ParsingTests.ParseSample1.Replace ("\n", "\r");
-			string MacOutput = OutputSample1.Replace ("\\n", "\\r").Replace ("\n", "\r");;
+			string MacInput = ParsingTests.ParseSample1.RenormalizeLineEndingsTo ("\r");
+			string MacOutput = OutputSample1.Replace ("\\n", "\\r").RenormalizeLineEndingsTo ("\r");;
 			Generate (MacInput, MacOutput, "\r");
 		}
 
 		[Test]
 		public void GenerateWindowsNewlines ()
 		{
-			string WinInput = ParsingTests.ParseSample1.Replace ("\n", "\r\n");
-			string WinOutput = OutputSample1.Replace ("\\n", "\\r\\n").Replace ("\n", "\r\n");
+			string WinInput = ParsingTests.ParseSample1.RenormalizeLineEndingsTo ("\r\n");
+			string WinOutput = OutputSample1.Replace ("\\n", "\\r\\n").RenormalizeLineEndingsTo ("\r\n");
 			Generate (WinInput, WinOutput, "\r\n");
 		}
 
@@ -110,7 +110,7 @@ namespace Mono.TextTemplating.Tests
 		{
 			DummyHost host = new DummyHost ();
 			string className = "GeneratedTextTransformation4f504ca0";
-			string code = GenerateCode (host, input, className, newline);
+			string code = GenerateCode (host, input.RenormalizeLineEndingsTo (newline), className, newline);
 			Assert.AreEqual (0, host.Errors.Count);
 
 			var generated = TemplatingEngineHelper.CleanCodeDom (code, newline);

--- a/Mono.TextTemplating.Tests/ParsingTests.cs
+++ b/Mono.TextTemplating.Tests/ParsingTests.cs
@@ -24,7 +24,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 
@@ -44,7 +43,7 @@ var foo = 5;
 #>
 Line Three <#= bar #>
 Line Four
-<#+
+<#+ " + @"
 var s = ""baz \\#>"";
 #>
 ";
@@ -53,7 +52,7 @@ var s = ""baz \\#>"";
 		public void TokenTest ()
 		{
 			string tf = "test.input";
-			Tokeniser tk = new Tokeniser (tf, ParseSample1);
+			Tokeniser tk = new Tokeniser (tf, ParseSample1.Replace ("\r", string.Empty));
 
 			//line 1
 			Assert.IsTrue (tk.Advance ());
@@ -139,7 +138,7 @@ var s = ""baz \\#>"";
 			string tf = "test.input";
 
 			ParsedTemplate pt = new ParsedTemplate ("test.input");
-			Tokeniser tk = new Tokeniser (tf, ParseSample1);
+			Tokeniser tk = new Tokeniser (tf, ParseSample1.RenormalizeLineEndingsTo ("\n"));
 			DummyHost host = new DummyHost ();
 			pt.Parse (host, tk);
 

--- a/Mono.TextTemplating.Tests/ParsingTests.cs
+++ b/Mono.TextTemplating.Tests/ParsingTests.cs
@@ -1,21 +1,21 @@
-// 
+//
 // Test.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,12 +30,12 @@ using NUnit.Framework;
 
 namespace Mono.TextTemplating.Tests
 {
-	
-	
+
+
 	[TestFixture]
 	public class ParsingTests
 	{
-		public static string ParseSample1 = 
+		public static string ParseSample1 =
 @"<#@ template language=""C#v3.5"" #>
 Line One
 Line Two
@@ -44,17 +44,17 @@ var foo = 5;
 #>
 Line Three <#= bar #>
 Line Four
-<#+ 
+<#+
 var s = ""baz \\#>"";
 #>
 ";
-		
+
 		[Test]
 		public void TokenTest ()
 		{
 			string tf = "test.input";
 			Tokeniser tk = new Tokeniser (tf, ParseSample1);
-			
+
 			//line 1
 			Assert.IsTrue (tk.Advance ());
 			Assert.AreEqual (new Location (tf, 1, 1), tk.Location);
@@ -80,13 +80,13 @@ var s = ""baz \\#>"";
 			Assert.AreEqual ("C#v3.5", tk.Value);
 			Assert.IsTrue (tk.Advance ());
 			Assert.AreEqual (State.Directive, tk.State);
-			
+
 			//line 2, 3
 			Assert.IsTrue (tk.Advance ());
 			Assert.AreEqual (new Location (tf, 2, 1), tk.Location);
 			Assert.AreEqual (State.Content, tk.State);
 			Assert.AreEqual ("Line One\nLine Two\n", tk.Value);
-			
+
 			//line 4, 5, 6
 			Assert.IsTrue (tk.Advance ());
 			Assert.AreEqual (new Location (tf, 4, 1), tk.TagStartLocation);
@@ -94,7 +94,7 @@ var s = ""baz \\#>"";
 			Assert.AreEqual (new Location (tf, 6, 3), tk.TagEndLocation);
 			Assert.AreEqual (State.Block, tk.State);
 			Assert.AreEqual ("\nvar foo = 5;\n", tk.Value);
-			
+
 			//line 7
 			Assert.IsTrue (tk.Advance ());
 			Assert.AreEqual (new Location (tf, 7, 1), tk.Location);
@@ -106,13 +106,13 @@ var s = ""baz \\#>"";
 			Assert.AreEqual (new Location (tf, 7, 22), tk.TagEndLocation);
 			Assert.AreEqual (State.Expression, tk.State);
 			Assert.AreEqual (" bar ", tk.Value);
-			
+
 			//line 8
 			Assert.IsTrue (tk.Advance ());
 			Assert.AreEqual (new Location (tf, 7, 22), tk.Location);
 			Assert.AreEqual (State.Content, tk.State);
 			Assert.AreEqual ("\nLine Four\n", tk.Value);
-			
+
 			//line 9, 10, 11
 			Assert.IsTrue (tk.Advance ());
 			Assert.AreEqual (new Location (tf, 9, 1), tk.TagStartLocation);
@@ -120,72 +120,72 @@ var s = ""baz \\#>"";
 			Assert.AreEqual (new Location (tf, 11, 3), tk.TagEndLocation);
 			Assert.AreEqual (State.Helper, tk.State);
 			Assert.AreEqual (" \nvar s = \"baz \\\\#>\";\n", tk.Value);
-			
+
 			//line 12
 			Assert.IsTrue (tk.Advance ());
 			Assert.AreEqual (new Location (tf, 12, 1), tk.Location);
 			Assert.AreEqual (State.Content, tk.State);
 			Assert.AreEqual ("", tk.Value);
-			
+
 			//EOF
 			Assert.IsFalse (tk.Advance ());
 			Assert.AreEqual (new Location (tf, 12, 1), tk.Location);
 			Assert.AreEqual (State.EOF, tk.State);
 		}
-		
+
 		[Test]
 		public void ParseTest ()
 		{
 			string tf = "test.input";
-			
+
 			ParsedTemplate pt = new ParsedTemplate ("test.input");
 			Tokeniser tk = new Tokeniser (tf, ParseSample1);
 			DummyHost host = new DummyHost ();
 			pt.Parse (host, tk);
-			
+
 			Assert.AreEqual (0, pt.Errors.Count);
 			var content = new List<TemplateSegment> (pt.Content);
 			var dirs = new List<Directive> (pt.Directives);
-			
+
 			Assert.AreEqual (1, dirs.Count);
 			Assert.AreEqual (6, content.Count);
-			
+
 			Assert.AreEqual ("template", dirs[0].Name);
 			Assert.AreEqual (1, dirs[0].Attributes.Count);
 			Assert.AreEqual ("C#v3.5", dirs[0].Attributes["language"]);
 			Assert.AreEqual (new Location (tf, 1, 1), dirs[0].TagStartLocation);
 			Assert.AreEqual (new Location (tf, 1, 34), dirs[0].EndLocation);
-			
+
 			Assert.AreEqual ("Line One\nLine Two\n", content[0].Text);
 			Assert.AreEqual ("\nvar foo = 5;\n", content[1].Text);
 			Assert.AreEqual ("Line Three ", content[2].Text);
 			Assert.AreEqual (" bar ", content[3].Text);
 			Assert.AreEqual ("\nLine Four\n", content[4].Text);
 			Assert.AreEqual (" \nvar s = \"baz \\\\#>\";\n", content[5].Text);
-			
+
 			Assert.AreEqual (SegmentType.Content, content[0].Type);
 			Assert.AreEqual (SegmentType.Block, content[1].Type);
 			Assert.AreEqual (SegmentType.Content, content[2].Type);
 			Assert.AreEqual (SegmentType.Expression, content[3].Type);
 			Assert.AreEqual (SegmentType.Content, content[4].Type);
 			Assert.AreEqual (SegmentType.Helper, content[5].Type);
-			
+
 			Assert.AreEqual (new Location (tf, 4, 1), content[1].TagStartLocation);
 			Assert.AreEqual (new Location (tf, 7, 12), content[3].TagStartLocation);
 			Assert.AreEqual (new Location (tf, 9, 1), content[5].TagStartLocation);
-			
+
 			Assert.AreEqual (new Location (tf, 2, 1), content[0].StartLocation);
 			Assert.AreEqual (new Location (tf, 4, 3), content[1].StartLocation);
 			Assert.AreEqual (new Location (tf, 7, 1), content[2].StartLocation);
 			Assert.AreEqual (new Location (tf, 7, 15), content[3].StartLocation);
 			Assert.AreEqual (new Location (tf, 7, 22), content[4].StartLocation);
 			Assert.AreEqual (new Location (tf, 9, 4), content[5].StartLocation);
-			
+
 			Assert.AreEqual (new Location (tf, 6, 3), content[1].EndLocation);
 			Assert.AreEqual (new Location (tf, 7, 22), content[3].EndLocation);
 			Assert.AreEqual (new Location (tf, 11, 3), content[5].EndLocation);
 		}
-		
-		
+
+
 	}
 }

--- a/Mono.TextTemplating.Tests/TemplateEnginePreprocessTemplateTests.cs
+++ b/Mono.TextTemplating.Tests/TemplateEnginePreprocessTemplateTests.cs
@@ -1,21 +1,21 @@
-// 
+//
 // TemplateEnginePreprocessTemplateTests.cs
-//  
+//
 // Author:
 //       Matt Ward
-// 
+//
 // Copyright (c) 2011 Matt Ward
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -35,29 +35,29 @@ namespace Mono.TextTemplating.Tests
 {
 	[TestFixture]
 	public class TemplateEnginePreprocessTemplateTests
-	{	
+	{
 		[Test]
 		public void Preprocess ()
 		{
-			string input = 
+			string input =
 				"<#@ template language=\"C#\" #>\r\n" +
 				"Test\r\n";
-			
+
 			string expectedOutput = TemplatingEngineHelper.CleanCodeDom (OutputSample1, "\n");
 			string output = Preprocess (input);
-			
+
 			Assert.AreEqual (expectedOutput, output);
 		}
-		
+
 		[Test]
 		public void Preprocess_ControlBlockAfterIncludedTemplateWithClassFeatureBlock_ReturnsValidCSharpOutput ()
 		{
 			string input = InputTemplate_ControlBlockAfterIncludedTemplateWithClassFeatureBlock;
 			DummyHost host = CreateDummyHostForControlBlockAfterIncludedTemplateWithClassFeatureBlockTest ();
-			
+
 			string expectedOutput = TemplatingEngineHelper.CleanCodeDom (Output_ControlBlockAfterIncludedTemplateWithClassFeatureBlock, "\n");
 			string output = Preprocess (input, host);
-			
+
 			Assert.AreEqual (expectedOutput, output, output);
 		}
 
@@ -70,22 +70,22 @@ namespace Mono.TextTemplating.Tests
 
 			Assert.AreEqual (expectedOutput, output, output);
 		}
-		
+
 		#region Helpers
-		
+
 		string Preprocess (string input)
 		{
 			DummyHost host = new DummyHost ();
 			return Preprocess (input, host);
 		}
-		
+
 		string Preprocess (string input, DummyHost host)
 		{
 			string className = "PreprocessedTemplate";
 			string classNamespace = "Templating";
 			string language = null;
 			string[] references = null;
-			
+
 			TemplatingEngine engine = new TemplatingEngine ();
 			string output = engine.PreprocessTemplate (input, host, className, classNamespace, out language, out references);
 			ReportErrors (host.Errors);
@@ -94,25 +94,25 @@ namespace Mono.TextTemplating.Tests
 			}
 			return null;
 		}
-		
+
 		void ReportErrors(CompilerErrorCollection errors)
 		{
 			foreach (CompilerError error in errors) {
 				Console.WriteLine(error.ErrorText);
 			}
 		}
-		
+
 		DummyHost CreateDummyHostForControlBlockAfterIncludedTemplateWithClassFeatureBlockTest()
 		{
 			DummyHost host = new DummyHost ();
-			
+
 			string includeTemplateFileName = @"d:\test\IncludedFile.tt";
 			host.Locations.Add (includeTemplateFileName, includeTemplateFileName);
 			host.Contents.Add (includeTemplateFileName, IncludedTemplate_ControlBlockAfterIncludedTemplate);
-			
+
 			return host;
 		}
-		
+
 		#endregion
 
 		#region Input templates
@@ -137,7 +137,7 @@ Text Block 3
     }
 #>
 ";
-		
+
 		public static string IncludedTemplate_ControlBlockAfterIncludedTemplate =
 @"
 <#@ template debug=""false"" language=""C#"" #>
@@ -162,46 +162,46 @@ Included Method Body Text Block
 ";
 
 		#endregion
-		
+
 		#region Expected output strings
-		
-		public static string OutputSample1 = 
+
+		public static string OutputSample1 =
 @"
 namespace Templating {
-    
-    
+
+
     public partial class PreprocessedTemplate : PreprocessedTemplateBase {
-        
+
         public virtual string TransformText() {
             this.GenerationEnvironment = null;
-            
+
             #line 2 """"
 
             this.Write(""Test\r\n"");
-            
+
             #line default
             #line hidden
             return this.GenerationEnvironment.ToString();
         }
-        
+
         public virtual void Initialize() {
         }
     }
-    
+
     public class PreprocessedTemplateBase {
-        
+
         private global::System.Text.StringBuilder builder;
-        
+
         private global::System.Collections.Generic.IDictionary<string, object> session;
-        
+
         private global::System.CodeDom.Compiler.CompilerErrorCollection errors;
-        
+
         private string currentIndent = string.Empty;
-        
+
         private global::System.Collections.Generic.Stack<int> indents;
-        
+
         private ToStringInstanceHelper _toStringHelper = new ToStringInstanceHelper();
-        
+
         public virtual global::System.Collections.Generic.IDictionary<string, object> Session {
             get {
                 return this.session;
@@ -210,7 +210,7 @@ namespace Templating {
                 this.session = value;
             }
         }
-        
+
         public global::System.Text.StringBuilder GenerationEnvironment {
             get {
                 if ((this.builder == null)) {
@@ -222,7 +222,7 @@ namespace Templating {
                 this.builder = value;
             }
         }
-        
+
         protected global::System.CodeDom.Compiler.CompilerErrorCollection Errors {
             get {
                 if ((this.errors == null)) {
@@ -231,13 +231,13 @@ namespace Templating {
                 return this.errors;
             }
         }
-        
+
         public string CurrentIndent {
             get {
                 return this.currentIndent;
             }
         }
-        
+
         private global::System.Collections.Generic.Stack<int> Indents {
             get {
                 if ((this.indents == null)) {
@@ -246,23 +246,23 @@ namespace Templating {
                 return this.indents;
             }
         }
-        
+
         public ToStringInstanceHelper ToStringHelper {
             get {
                 return this._toStringHelper;
             }
         }
-        
+
         public void Error(string message) {
             this.Errors.Add(new global::System.CodeDom.Compiler.CompilerError(null, -1, -1, null, message));
         }
-        
+
         public void Warning(string message) {
             global::System.CodeDom.Compiler.CompilerError val = new global::System.CodeDom.Compiler.CompilerError(null, -1, -1, null, message);
             val.IsWarning = true;
             this.Errors.Add(val);
         }
-        
+
         public string PopIndent() {
             if ((this.Indents.Count == 0)) {
                 return string.Empty;
@@ -272,40 +272,40 @@ namespace Templating {
             this.currentIndent = this.currentIndent.Substring(0, lastPos);
             return last;
         }
-        
+
         public void PushIndent(string indent) {
             this.Indents.Push(indent.Length);
             this.currentIndent = (this.currentIndent + indent);
         }
-        
+
         public void ClearIndent() {
             this.currentIndent = string.Empty;
             this.Indents.Clear();
         }
-        
+
         public void Write(string textToAppend) {
             this.GenerationEnvironment.Append(textToAppend);
         }
-        
+
         public void Write(string format, params object[] args) {
             this.GenerationEnvironment.AppendFormat(format, args);
         }
-        
+
         public void WriteLine(string textToAppend) {
             this.GenerationEnvironment.Append(this.currentIndent);
             this.GenerationEnvironment.AppendLine(textToAppend);
         }
-        
+
         public void WriteLine(string format, params object[] args) {
             this.GenerationEnvironment.Append(this.currentIndent);
             this.GenerationEnvironment.AppendFormat(format, args);
             this.GenerationEnvironment.AppendLine();
         }
-        
+
         public class ToStringInstanceHelper {
-            
+
             private global::System.IFormatProvider formatProvider = global::System.Globalization.CultureInfo.InvariantCulture;
-            
+
             public global::System.IFormatProvider FormatProvider {
                 get {
                     return this.formatProvider;
@@ -316,7 +316,7 @@ namespace Templating {
                     }
                 }
             }
-            
+
             public string ToStringWithCulture(object objectToConvert) {
                 if ((objectToConvert == null)) {
                     throw new global::System.ArgumentNullException(""objectToConvert"");
@@ -342,131 +342,131 @@ namespace Templating {
 		public static string Output_ControlBlockAfterIncludedTemplateWithClassFeatureBlock =
 @"
 namespace Templating {
-    
-    
+
+
     public partial class PreprocessedTemplate : PreprocessedTemplateBase {
-        
-        
+
+
         #line 14 """"
-        
+
     void TemplateMethod()
     {
     }
 
         #line default
         #line hidden
-        
-        
+
+
         #line 7 ""d:\test\IncludedFile.tt""
-        
+
     void IncludedMethod()
     {
 
         #line default
         #line hidden
-        
-        
+
+
         #line 11 ""d:\test\IncludedFile.tt""
         this.Write(""Included Method Body Text Block\n"");
 
         #line default
         #line hidden
-        
-        
+
+
         #line 12 ""d:\test\IncludedFile.tt""
-        
+
     }
 
         #line default
         #line hidden
-        
+
         public virtual string TransformText() {
             this.GenerationEnvironment = null;
-            
+
             #line 1 """"
             this.Write(""\n"");
-            
+
             #line default
             #line hidden
-            
+
             #line 4 """"
             this.Write(""Text Block 1\n"");
-            
+
             #line default
             #line hidden
-            
+
             #line 5 """"
 
     this.TemplateMethod();
 
-            
+
             #line default
             #line hidden
-            
+
             #line 8 """"
             this.Write(""Text Block 2\n"");
-            
+
             #line default
             #line hidden
-            
+
             #line 1 ""d:\test\IncludedFile.tt""
             this.Write(""\n"");
-            
+
             #line default
             #line hidden
-            
+
             #line 4 ""d:\test\IncludedFile.tt""
             this.Write(""Included Text Block 1\n"");
-            
+
             #line default
             #line hidden
-            
+
             #line 5 ""d:\test\IncludedFile.tt""
- this.WriteLine(""Included statement block""); 
-            
+ this.WriteLine(""Included statement block"");
+
             #line default
             #line hidden
-            
+
             #line 6 ""d:\test\IncludedFile.tt""
             this.Write(""Included Text Block 2\n"");
-            
+
             #line default
             #line hidden
-            
+
             #line 10 """"
             this.Write(""Text Block 3\n"");
-            
+
             #line default
             #line hidden
-            
+
             #line 11 """"
 
     this.IncludedMethod();
 
-            
+
             #line default
             #line hidden
             return this.GenerationEnvironment.ToString();
         }
-        
+
         public virtual void Initialize() {
         }
     }
-    
+
     public class PreprocessedTemplateBase {
-        
+
         private global::System.Text.StringBuilder builder;
-        
+
         private global::System.Collections.Generic.IDictionary<string, object> session;
-        
+
         private global::System.CodeDom.Compiler.CompilerErrorCollection errors;
-        
+
         private string currentIndent = string.Empty;
-        
+
         private global::System.Collections.Generic.Stack<int> indents;
-        
+
         private ToStringInstanceHelper _toStringHelper = new ToStringInstanceHelper();
-        
+
         public virtual global::System.Collections.Generic.IDictionary<string, object> Session {
             get {
                 return this.session;
@@ -475,7 +475,7 @@ namespace Templating {
                 this.session = value;
             }
         }
-        
+
         public global::System.Text.StringBuilder GenerationEnvironment {
             get {
                 if ((this.builder == null)) {
@@ -487,7 +487,7 @@ namespace Templating {
                 this.builder = value;
             }
         }
-        
+
         protected global::System.CodeDom.Compiler.CompilerErrorCollection Errors {
             get {
                 if ((this.errors == null)) {
@@ -496,13 +496,13 @@ namespace Templating {
                 return this.errors;
             }
         }
-        
+
         public string CurrentIndent {
             get {
                 return this.currentIndent;
             }
         }
-        
+
         private global::System.Collections.Generic.Stack<int> Indents {
             get {
                 if ((this.indents == null)) {
@@ -511,23 +511,23 @@ namespace Templating {
                 return this.indents;
             }
         }
-        
+
         public ToStringInstanceHelper ToStringHelper {
             get {
                 return this._toStringHelper;
             }
         }
-        
+
         public void Error(string message) {
             this.Errors.Add(new global::System.CodeDom.Compiler.CompilerError(null, -1, -1, null, message));
         }
-        
+
         public void Warning(string message) {
             global::System.CodeDom.Compiler.CompilerError val = new global::System.CodeDom.Compiler.CompilerError(null, -1, -1, null, message);
             val.IsWarning = true;
             this.Errors.Add(val);
         }
-        
+
         public string PopIndent() {
             if ((this.Indents.Count == 0)) {
                 return string.Empty;
@@ -537,40 +537,40 @@ namespace Templating {
             this.currentIndent = this.currentIndent.Substring(0, lastPos);
             return last;
         }
-        
+
         public void PushIndent(string indent) {
             this.Indents.Push(indent.Length);
             this.currentIndent = (this.currentIndent + indent);
         }
-        
+
         public void ClearIndent() {
             this.currentIndent = string.Empty;
             this.Indents.Clear();
         }
-        
+
         public void Write(string textToAppend) {
             this.GenerationEnvironment.Append(textToAppend);
         }
-        
+
         public void Write(string format, params object[] args) {
             this.GenerationEnvironment.AppendFormat(format, args);
         }
-        
+
         public void WriteLine(string textToAppend) {
             this.GenerationEnvironment.Append(this.currentIndent);
             this.GenerationEnvironment.AppendLine(textToAppend);
         }
-        
+
         public void WriteLine(string format, params object[] args) {
             this.GenerationEnvironment.Append(this.currentIndent);
             this.GenerationEnvironment.AppendFormat(format, args);
             this.GenerationEnvironment.AppendLine();
         }
-        
+
         public class ToStringInstanceHelper {
-            
+
             private global::System.IFormatProvider formatProvider = global::System.Globalization.CultureInfo.InvariantCulture;
-            
+
             public global::System.IFormatProvider FormatProvider {
                 get {
                     return this.formatProvider;
@@ -581,7 +581,7 @@ namespace Templating {
                     }
                 }
             }
-            
+
             public string ToStringWithCulture(object objectToConvert) {
                 if ((objectToConvert == null)) {
                     throw new global::System.ArgumentNullException(""objectToConvert"");
@@ -604,24 +604,24 @@ namespace Templating {
 }
 ";
 
-		public static string Output_CaptureEncodingAndExtension = 
+		public static string Output_CaptureEncodingAndExtension =
 
 		@"namespace Templating {
-    
-    
+
+
     public partial class PreprocessedTemplate : Foo {
-        
+
         public override string TransformText() {
             this.GenerationEnvironment = null;
-            
+
             #line 1 """"
             this.Write(""\n"");
-            
+
             #line default
             #line hidden
             return this.GenerationEnvironment.ToString();
         }
-        
+
         public override void Initialize() {
             if ((this.Host != null)) {
                 this.Host.SetFileExtension("".cs"");

--- a/Mono.TextTemplating.Tests/TemplateEnginePreprocessTemplateTests.cs
+++ b/Mono.TextTemplating.Tests/TemplateEnginePreprocessTemplateTests.cs
@@ -27,7 +27,6 @@
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
-using System.IO;
 using NUnit.Framework;
 using Microsoft.VisualStudio.TextTemplating;
 
@@ -56,7 +55,7 @@ namespace Mono.TextTemplating.Tests
 			DummyHost host = CreateDummyHostForControlBlockAfterIncludedTemplateWithClassFeatureBlockTest ();
 
 			string expectedOutput = TemplatingEngineHelper.CleanCodeDom (Output_ControlBlockAfterIncludedTemplateWithClassFeatureBlock, "\n");
-			string output = Preprocess (input, host);
+			string output = Preprocess (input, host).Replace (@"\r", string.Empty);
 
 			Assert.AreEqual (expectedOutput, output, output);
 		}
@@ -64,7 +63,7 @@ namespace Mono.TextTemplating.Tests
 		[Test]
 		public void CaptureEncodingAndExtension ()
 		{
-			string input = InputTemplate_CaptureEncodingAndExtension;
+			string input = InputTemplate_CaptureEncodingAndExtension.RenormalizeLineEndingsTo ("\n");
 			string output = Preprocess (input);
 			string expectedOutput = TemplatingEngineHelper.CleanCodeDom (Output_CaptureEncodingAndExtension, "\n");
 

--- a/Mono.TextTemplating.Tests/TemplatingEngineHelper.cs
+++ b/Mono.TextTemplating.Tests/TemplatingEngineHelper.cs
@@ -1,21 +1,21 @@
-// 
+//
 // Test.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Mono.TextTemplating/AssemblyInfo.cs
+++ b/Mono.TextTemplating/AssemblyInfo.cs
@@ -1,21 +1,21 @@
-// 
+//
 // AssemblyInfo.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/DirectiveProcessor.cs
+++ b/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/DirectiveProcessor.cs
@@ -1,21 +1,21 @@
-// 
+//
 // DirectiveProcessor.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -38,20 +38,20 @@ namespace Microsoft.VisualStudio.TextTemplating
 		protected DirectiveProcessor ()
 		{
 		}
-		
+
 		public virtual void Initialize (ITextTemplatingEngineHost host)
 		{
 			if (host == null)
 				throw new ArgumentNullException ("host");
 		}
-		
+
 		public virtual void StartProcessingRun (CodeDomProvider languageProvider, string templateContents, CompilerErrorCollection errors)
 		{
 			if (languageProvider == null)
 				throw new ArgumentNullException ("languageProvider");
 			this.errors = errors;
 		}
-		
+
 		public abstract void FinishProcessingRun ();
 		public abstract string GetClassCodeForProcessingRun ();
 		public abstract string[] GetImportsForProcessingRun ();

--- a/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/DirectiveProcessorException.cs
+++ b/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/DirectiveProcessorException.cs
@@ -1,21 +1,21 @@
-// 
+//
 // DirectiveProcessorException.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,25 +29,25 @@ using System.Runtime.Serialization;
 
 namespace Microsoft.VisualStudio.TextTemplating
 {
-	
+
 	[Serializable]
 	public class DirectiveProcessorException : Exception
 	{
-		
+
 		public DirectiveProcessorException ()
 		{
 		}
-		
+
 		public DirectiveProcessorException (string message)
 			: base (message)
 		{
 		}
-		
+
 		public DirectiveProcessorException (SerializationInfo info, StreamingContext context)
 			: base (info, context)
 		{
 		}
-		
+
 		public DirectiveProcessorException (string message, Exception inner)
 			: base (message, inner)
 		{

--- a/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/EncodingHelper.cs
+++ b/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/EncodingHelper.cs
@@ -1,21 +1,21 @@
-// 
+//
 // EncodingHelper.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2010 Novell, Inc.
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/Engine.cs
+++ b/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/Engine.cs
@@ -1,21 +1,21 @@
-// 
+//
 // Engine.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,18 +33,18 @@ namespace Microsoft.VisualStudio.TextTemplating
 	public class Engine : ITextTemplatingEngine
 	{
 		TemplatingEngine engine = new TemplatingEngine ();
-		
+
 		public string ProcessTemplate (string content, ITextTemplatingEngineHost host)
 		{
 			return engine.ProcessTemplate (content, host);
 		}
-		
-		public string PreprocessTemplate (string content, ITextTemplatingEngineHost host, string className, 
+
+		public string PreprocessTemplate (string content, ITextTemplatingEngineHost host, string className,
 			string classNamespace, out string language, out string[] references)
 		{
 			return engine.PreprocessTemplate (content, host, className, classNamespace, out language, out references);
 		}
-		
+
 		public const string CacheAssembliesOptionString = "CacheAssemblies";
 	}
 }

--- a/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/Interfaces.cs
+++ b/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/Interfaces.cs
@@ -1,21 +1,21 @@
-// 
+//
 // ITextTemplatingEngineHost.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009-2010 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -76,8 +76,8 @@ namespace Microsoft.VisualStudio.TextTemplating
 	{
 		Guid Id { get; }
 	}
-	
-	public interface ITextTemplatingSessionHost	
+
+	public interface ITextTemplatingSessionHost
 	{
 		ITextTemplatingSession CreateSession ();
 		ITextTemplatingSession Session { get; set; }

--- a/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/RequiresProvidesDirectiveProcessor.cs
+++ b/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/RequiresProvidesDirectiveProcessor.cs
@@ -1,21 +1,21 @@
-// 
+//
 // RequiresProvidesDirectiveProcessor.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,8 +31,8 @@ using System.Text;
 
 namespace Microsoft.VisualStudio.TextTemplating
 {
-	
-	
+
+
 	public abstract class RequiresProvidesDirectiveProcessor : DirectiveProcessor
 	{
 		bool isInProcessingRun;
@@ -41,86 +41,86 @@ namespace Microsoft.VisualStudio.TextTemplating
 		StringBuilder postInitBuffer = new StringBuilder ();
 		StringBuilder codeBuffer = new StringBuilder ();
 		CodeDomProvider languageProvider;
-		
+
 		protected RequiresProvidesDirectiveProcessor ()
 		{
 		}
-		
+
 		public override void Initialize (ITextTemplatingEngineHost host)
 		{
 			base.Initialize (host);
 			this.host = host;
 		}
-		
+
 		protected abstract void InitializeProvidesDictionary (string directiveName, IDictionary<string, string> providesDictionary);
 		protected abstract void InitializeRequiresDictionary (string directiveName, IDictionary<string, string> requiresDictionary);
 		protected abstract string FriendlyName { get; }
-		
-		protected abstract void GeneratePostInitializationCode (string directiveName, StringBuilder codeBuffer, CodeDomProvider languageProvider, 
+
+		protected abstract void GeneratePostInitializationCode (string directiveName, StringBuilder codeBuffer, CodeDomProvider languageProvider,
 			IDictionary<string, string> requiresArguments, IDictionary<string, string> providesArguments);
 		protected abstract void GeneratePreInitializationCode (string directiveName, StringBuilder codeBuffer, CodeDomProvider languageProvider,
 			IDictionary<string, string> requiresArguments, IDictionary<string, string> providesArguments);
 		protected abstract void GenerateTransformCode (string directiveName, StringBuilder codeBuffer, CodeDomProvider languageProvider,
 			IDictionary<string, string> requiresArguments, IDictionary<string, string> providesArguments);
-		
+
 		protected virtual void PostProcessArguments (string directiveName, IDictionary<string, string> requiresArguments,
 			IDictionary<string, string> providesArguments)
 		{
 		}
-		
+
 		public override string GetClassCodeForProcessingRun ()
 		{
 			AssertNotProcessing ();
 			return codeBuffer.ToString ();
 		}
-		
+
 		public override string[] GetImportsForProcessingRun ()
 		{
 			AssertNotProcessing ();
 			return null;
 		}
-		
+
 		public override string[] GetReferencesForProcessingRun ()
 		{
 			AssertNotProcessing ();
 			return null;
 		}
-		
+
 		public override string GetPostInitializationCodeForProcessingRun ()
 		{
 			AssertNotProcessing ();
 			return postInitBuffer.ToString ();
 		}
-		
+
 		public override string GetPreInitializationCodeForProcessingRun ()
 		{
 			AssertNotProcessing ();
 			return preInitBuffer.ToString ();
 		}
-		
+
 		public override void StartProcessingRun (CodeDomProvider languageProvider, string templateContents, CompilerErrorCollection errors)
 		{
 			AssertNotProcessing ();
 			isInProcessingRun = true;
 			base.StartProcessingRun (languageProvider, templateContents, errors);
-			
+
 			this.languageProvider = languageProvider;
 			codeBuffer.Length = 0;
 			preInitBuffer.Length = 0;
 			postInitBuffer.Length = 0;
 		}
-		
+
 		public override void FinishProcessingRun ()
 		{
 			isInProcessingRun = false;
 		}
-		
+
 		void AssertNotProcessing ()
 		{
 			if (isInProcessingRun)
 				throw new InvalidOperationException ();
 		}
-		
+
 		//FIXME: handle escaping
 		IEnumerable<KeyValuePair<string,string>> ParseArgs (string args)
 		{
@@ -132,63 +132,63 @@ namespace Microsoft.VisualStudio.TextTemplating
 				yield return new KeyValuePair<string, string> (k, v);
 			}
 		}
-		
+
 		public override void ProcessDirective (string directiveName, IDictionary<string, string> arguments)
 		{
 			if (directiveName == null)
 				throw new ArgumentNullException ("directiveName");
 			if (arguments == null)
 				throw new ArgumentNullException ("arguments");
-			
+
 			var providesDictionary = new Dictionary<string,string> ();
 			var requiresDictionary = new Dictionary<string,string> ();
-			
+
 			string provides;
 			if (arguments.TryGetValue ("provides", out provides)) {
 				foreach (var arg in ParseArgs (provides)) {
 					providesDictionary.Add (arg.Key, arg.Value);
 				}
 			}
-			
+
 			string requires;
 			if (arguments.TryGetValue ("requires", out requires)) {
 				foreach (var arg in ParseArgs (requires)) {
 					requiresDictionary.Add (arg.Key, arg.Value);
 				}
 			}
-			
+
 			InitializeRequiresDictionary (directiveName, requiresDictionary);
 			InitializeProvidesDictionary (directiveName, providesDictionary);
-			
+
 			var id = ProvideUniqueId (directiveName, arguments, requiresDictionary, providesDictionary);
-			
+
 			foreach (var req in requiresDictionary) {
 				var val = host.ResolveParameterValue (id, FriendlyName, req.Key);
 				if (val != null)
-					requiresDictionary[req.Key] = val; 
+					requiresDictionary[req.Key] = val;
 				else if (req.Value == null)
 					throw new DirectiveProcessorException ("Could not resolve required value '" + req.Key + "'");
 			}
-			
+
 			foreach (var req in providesDictionary) {
 				var val = host.ResolveParameterValue (id, FriendlyName, req.Key);
 				if (val != null)
 					providesDictionary[req.Key] = val;
 			}
-			
+
 			PostProcessArguments (directiveName, requiresDictionary, providesDictionary);
-			
+
 			GeneratePreInitializationCode (directiveName, preInitBuffer, languageProvider, requiresDictionary, providesDictionary);
 			GeneratePostInitializationCode (directiveName, postInitBuffer, languageProvider, requiresDictionary, providesDictionary);
 			GenerateTransformCode (directiveName, codeBuffer, languageProvider, requiresDictionary, providesDictionary);
 		}
-		
+
 		protected virtual string ProvideUniqueId (string directiveName, IDictionary<string, string> arguments,
 			IDictionary<string, string> requiresArguments, IDictionary<string, string> providesArguments)
 		{
 			return directiveName;
 		}
-		
+
 		protected ITextTemplatingEngineHost Host {
 			get { return host; }
 		}

--- a/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/TextTemplatingSession.cs
+++ b/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/TextTemplatingSession.cs
@@ -1,21 +1,21 @@
-// 
+//
 // TextTemplatingSession.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2010 Novell, Inc.
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -47,27 +47,27 @@ namespace Microsoft.VisualStudio.TextTemplating
 		{
 			this.Id = id;
 		}
-		
+
 		public Guid Id {
 			get; private set;
 		}
-		
+
 		public override int GetHashCode ()
 		{
 			return Id.GetHashCode ();
 		}
-		
+
 		public override bool Equals (object obj)
 		{
 			var o = obj as TextTemplatingSession;
 			return o != null && o.Equals (this);
 		}
-		
+
 		public bool Equals (Guid other)
 		{
 			return other.Equals (Id);
 		}
-		
+
 		public bool Equals (ITextTemplatingSession other)
 		{
 			return other != null && other.Id == this.Id;

--- a/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/TextTransformation.cs
+++ b/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/TextTransformation.cs
@@ -1,21 +1,21 @@
-// 
+//
 // TextTransformation.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -38,31 +38,31 @@ namespace Microsoft.VisualStudio.TextTemplating
 		CompilerErrorCollection errors;
 		StringBuilder builder;
 		bool endsWithNewline;
-		
+
 		public TextTransformation ()
 		{
 		}
-		
+
 		public virtual void Initialize ()
 		{
 		}
-		
+
 		public abstract string TransformText ();
-		
+
 		public virtual IDictionary<string, object> Session { get; set; }
-		
+
 		#region Errors
-		
+
 		public void Error (string message)
 		{
 			Errors.Add (new CompilerError ("", 0, 0, "", message));
 		}
-		
+
 		public void Warning (string message)
 		{
 			Errors.Add (new CompilerError ("", 0, 0, "", message) { IsWarning = true });
 		}
-		
+
 		protected internal CompilerErrorCollection Errors {
 			get {
 				if (errors == null)
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.TextTemplating
 				return errors;
 			}
 		}
-		
+
 		Stack<int> Indents {
 			get {
 				if (indents == null)
@@ -78,11 +78,11 @@ namespace Microsoft.VisualStudio.TextTemplating
 				return indents;
 			}
 		}
-		
+
 		#endregion
-		
+
 		#region Indents
-		
+
 		public string PopIndent ()
 		{
 			if (Indents.Count == 0)
@@ -90,9 +90,9 @@ namespace Microsoft.VisualStudio.TextTemplating
 			int lastPos = currentIndent.Length - Indents.Pop ();
 			string last = currentIndent.Substring (lastPos);
 			currentIndent = currentIndent.Substring (0, lastPos);
-			return last; 
+			return last;
 		}
-		
+
 		public void PushIndent (string indent)
 		{
 			if (indent == null)
@@ -100,21 +100,21 @@ namespace Microsoft.VisualStudio.TextTemplating
 			Indents.Push (indent.Length);
 			currentIndent += indent;
 		}
-		
+
 		public void ClearIndent ()
 		{
 			currentIndent = string.Empty;
 			Indents.Clear ();
 		}
-		
+
 		public string CurrentIndent {
 			get { return currentIndent; }
 		}
-		
+
 		#endregion
-		
+
 		#region Writing
-		
+
 		protected StringBuilder GenerationEnvironment {
 			get {
 				if (builder == null)
@@ -125,27 +125,27 @@ namespace Microsoft.VisualStudio.TextTemplating
 				builder = value;
 			}
 		}
-		
+
 		public void Write (string textToAppend)
 		{
 			if (string.IsNullOrEmpty (textToAppend))
 				return;
-			
+
 			if ((GenerationEnvironment.Length == 0 || endsWithNewline) && CurrentIndent.Length > 0) {
 				GenerationEnvironment.Append (CurrentIndent);
 			}
 			endsWithNewline = false;
-			
+
 			char last = textToAppend[textToAppend.Length-1];
 			if (last == '\n' || last == '\r') {
 				endsWithNewline = true;
 			}
-			
+
 			if (CurrentIndent.Length == 0) {
 				GenerationEnvironment.Append (textToAppend);
 				return;
 			}
-			
+
 			//insert CurrentIndent after every newline (\n, \r, \r\n)
 			//but if there's one at the end of the string, ignore it, it'll be handled next time thanks to endsWithNewline
 			int lastNewline = 0;
@@ -173,43 +173,43 @@ namespace Microsoft.VisualStudio.TextTemplating
 			else
 				GenerationEnvironment.Append (textToAppend);
 		}
-		
+
 		public void Write (string format, params object[] args)
 		{
 			Write (string.Format (format, args));
 		}
-		
+
 		public void WriteLine (string textToAppend)
 		{
 			Write (textToAppend);
 			GenerationEnvironment.AppendLine ();
 			endsWithNewline = true;
 		}
-		
+
 		public void WriteLine (string format, params object[] args)
 		{
 			WriteLine (string.Format (format, args));
 		}
 
 		#endregion
-		
+
 		#region Dispose
-		
+
 		public void Dispose ()
 		{
 			Dispose (true);
 			GC.SuppressFinalize (this);
 		}
-		
+
 		protected virtual void Dispose (bool disposing)
 		{
 		}
-		
+
 		~TextTransformation ()
 		{
 			Dispose (false);
 		}
-		
+
 		#endregion
 
 	}

--- a/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/ToStringHelper.cs
+++ b/Mono.TextTemplating/Microsoft.VisualStudio.TextTemplating/ToStringHelper.cs
@@ -1,21 +1,21 @@
-// 
+//
 // ToStringHelper.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.TextTemplating
 		static readonly object[] formatProviderAsParameterArray;
 
 		static IFormatProvider formatProvider = System.Globalization.CultureInfo.InvariantCulture;
-		
+
 		static ToStringHelper ()
 		{
 			formatProviderAsParameterArray = new object[] { formatProvider };
@@ -48,18 +48,18 @@ namespace Microsoft.VisualStudio.TextTemplating
 			IConvertible conv = objectToConvert as IConvertible;
 			if (conv != null)
 				return conv.ToString (formatProvider);
-			
+
 			var str = objectToConvert as string;
 			if (str != null)
 				return str;
-			
+
 			//TODO: implement a cache of types and DynamicMethods
 			MethodInfo mi = objectToConvert.GetType ().GetMethod ("ToString", new Type[] { typeof (IFormatProvider) });
 			if (mi != null)
 				return (string) mi.Invoke (objectToConvert, formatProviderAsParameterArray);
 			return objectToConvert.ToString ();
 		}
-		
+
 		public static IFormatProvider FormatProvider {
 			get { return (IFormatProvider)formatProviderAsParameterArray[0]; }
 			set { formatProviderAsParameterArray[0] = formatProvider = value; }

--- a/Mono.TextTemplating/Mono.TextTemplating/CompiledTemplate.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/CompiledTemplate.cs
@@ -1,21 +1,21 @@
-// 
+//
 // CompiledTemplate.cs
-//  
+//
 // Author:
 //       Nathan Baulch <nathan.baulch@gmail.com>
-// 
+//
 // Copyright (c) 2009 Nathan Baulch
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -62,8 +62,8 @@ namespace Mono.TextTemplating
 			//use Assembly.LoadFile instead
 			var assembly = System.Reflection.Assembly.LoadFile (results.PathToAssembly);
 			Type transformType = assembly.GetType (fullName);
-			//MS Templating Engine does not look on the type itself, 
-			//it checks only that required methods are exists in the compiled type 
+			//MS Templating Engine does not look on the type itself,
+			//it checks only that required methods are exists in the compiled type
 			textTransformation = Activator.CreateInstance (transformType);
 
 			//set the host property if it exists

--- a/Mono.TextTemplating/Mono.TextTemplating/CrossAppDomainAssemblyResolver.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/CrossAppDomainAssemblyResolver.cs
@@ -1,21 +1,21 @@
-// 
+//
 // CrossAppDomainAssemblyResolver.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2010 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -37,7 +37,7 @@ namespace Mono.TextTemplating
 	public class CrossAppDomainAssemblyResolver
 	{
 		readonly ParentDomainLookup parent = new ParentDomainLookup ();
-		
+
 		public System.Reflection.Assembly Resolve (object sender, ResolveEventArgs args)
 		{
 			var location = parent.GetAssemblyPath (args.Name);
@@ -45,7 +45,7 @@ namespace Mono.TextTemplating
 				return System.Reflection.Assembly.LoadFrom (location);
 			return null;
 		}
-		
+
 		class ParentDomainLookup : MarshalByRefObject
 		{
 			public string GetAssemblyPath (string name)

--- a/Mono.TextTemplating/Mono.TextTemplating/ParsedTemplate.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/ParsedTemplate.cs
@@ -1,21 +1,21 @@
-// 
+//
 // Template.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,7 +36,7 @@ namespace Mono.TextTemplating
 	{
 		readonly List<ISegment> importedHelperSegments = new List<ISegment> ();
 		readonly string rootFileName;
-		
+
 		public ParsedTemplate (string rootFileName)
 		{
 			this.rootFileName = rootFileName;
@@ -52,7 +52,7 @@ namespace Mono.TextTemplating
 				}
 			}
 		}
-		
+
 		public IEnumerable<TemplateSegment> Content {
 			get {
 				foreach (ISegment seg in RawSegments) {
@@ -87,7 +87,7 @@ namespace Mono.TextTemplating
 			bool addToImportedHelpers = false;
 			while ((skip || tokeniser.Advance ()) && tokeniser.State != State.EOF) {
 				skip = false;
-				ISegment seg = null;	
+				ISegment seg = null;
 				switch (tokeniser.State) {
 				case State.Block:
 					if (!string.IsNullOrEmpty (tokeniser.Value))
@@ -155,7 +155,7 @@ namespace Mono.TextTemplating
 			if (!isImport)
 				AppendAnyImportedHelperSegments ();
 		}
-		
+
 		void Import (ITextTemplatingEngineHost host, Directive includeDirective, string relativeToDirectory)
 		{
 			string fileName;
@@ -163,7 +163,7 @@ namespace Mono.TextTemplating
 				LogError ("Unexpected attributes in include directive", includeDirective.StartLocation);
 				return;
 			}
-			
+
 			//try to resolve path relative to the file that included it
 			if (relativeToDirectory != null && !Path.IsPathRooted (fileName)) {
 				string possible = Path.Combine (relativeToDirectory, fileName);
@@ -176,13 +176,13 @@ namespace Mono.TextTemplating
 			else
 				LogError ("Could not resolve include file '" + fileName + "'.", includeDirective.StartLocation);
 		}
-		
+
 		void AppendAnyImportedHelperSegments ()
 		{
 			RawSegments.AddRange (importedHelperSegments);
 			importedHelperSegments.Clear ();
 		}
-		
+
 		void LogError (string message, Location location, bool isWarning)
 		{
 			var err = new CompilerError ();
@@ -206,14 +206,14 @@ namespace Mono.TextTemplating
 
 		public void LogWarning (string message, Location location) => LogError (message, location, true);
 	}
-	
+
 	public interface ISegment
 	{
 		Location StartLocation { get; }
 		Location EndLocation { get; set; }
 		Location TagStartLocation {get; set; }
 	}
-	
+
 	public class TemplateSegment : ISegment
 	{
 		public TemplateSegment (SegmentType type, string text, Location start)
@@ -222,14 +222,14 @@ namespace Mono.TextTemplating
 			this.StartLocation = start;
 			this.Text = text;
 		}
-		
+
 		public SegmentType Type { get; private set; }
 		public string Text { get; private set; }
 		public Location TagStartLocation { get; set; }
 		public Location StartLocation { get; private set; }
 		public Location EndLocation { get; set; }
 	}
-	
+
 	public class Directive : ISegment
 	{
 		public Directive (string name, Location start)
@@ -238,13 +238,13 @@ namespace Mono.TextTemplating
 			Attributes = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase);
 			StartLocation = start;
 		}
-		
+
 		public string Name { get; private set; }
 		public Dictionary<string,string> Attributes { get; private set; }
 		public Location TagStartLocation { get; set; }
 		public Location StartLocation { get; private set; }
 		public Location EndLocation { get; set; }
-		
+
 		public string Extract (string key)
 		{
 			if (!Attributes.TryGetValue (key, out var value))
@@ -253,7 +253,7 @@ namespace Mono.TextTemplating
 			return value;
 		}
 	}
-	
+
 	public enum SegmentType
 	{
 		Block,
@@ -261,7 +261,7 @@ namespace Mono.TextTemplating
 		Content,
 		Helper
 	}
-	
+
 	public struct Location : IEquatable<Location>
 	{
 		public Location (string fileName, int line, int column) : this()
@@ -270,7 +270,7 @@ namespace Mono.TextTemplating
 			Column = column;
 			Line = line;
 		}
-		
+
 		public int Line { get; private set; }
 		public int Column { get; private set; }
 		public string FileName { get; private set; }

--- a/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
@@ -1,21 +1,21 @@
-// 
+//
 // TemplatingHost.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -57,7 +57,7 @@ namespace Mono.TextTemplating
 
 		//re-usable
 		TemplatingEngine engine;
-		
+
 		//per-run variables
 		Encoding encoding;
 
@@ -70,7 +70,7 @@ namespace Mono.TextTemplating
 		public string OutputFile { get; protected set; }
 		public string TemplateFile { get; protected set; }
 		public bool UseRelativeLinePragmas { get; set; }
-		
+
 		public TemplateGenerator ()
 		{
 			Refs.Add (typeof (TextTransformation).Assembly.Location);
@@ -79,7 +79,7 @@ namespace Mono.TextTemplating
 			Refs.Add (typeof (StringReader).Assembly.Location);
 			Imports.Add ("System");
 		}
-		
+
 		public CompiledTemplate CompileTemplate (string content)
 		{
 			if (string.IsNullOrEmpty (content))
@@ -87,10 +87,10 @@ namespace Mono.TextTemplating
 
 			Errors.Clear ();
 			encoding = Encoding.UTF8;
-			
+
 			return Engine.CompileTemplate (content, this);
 		}
-		
+
 		protected TemplatingEngine Engine {
 			get {
 				if (engine == null)
@@ -98,14 +98,14 @@ namespace Mono.TextTemplating
 				return engine;
 			}
 		}
-		
+
 		public bool ProcessTemplate (string inputFile, string outputFile)
 		{
 			if (string.IsNullOrEmpty (inputFile))
 				throw new ArgumentNullException (nameof (inputFile));
 			if (string.IsNullOrEmpty (outputFile))
 				throw new ArgumentNullException (nameof (outputFile));
-			
+
 			string content;
 			try {
 				content = File.ReadAllText (inputFile);
@@ -123,10 +123,10 @@ namespace Mono.TextTemplating
 			} catch (IOException ex) {
 				AddError ("Could not write output file '" + outputFile + "':\n" + ex);
 			}
-			
+
 			return !Errors.HasErrors;
 		}
-		
+
 		public bool ProcessTemplate (string inputFileName, string inputContent, ref string outputFileName, out string outputContent)
 		{
 			Errors.Clear ();
@@ -136,11 +136,11 @@ namespace Mono.TextTemplating
 			TemplateFile = inputFileName;
 			outputContent = Engine.ProcessTemplate (inputContent, this);
 			outputFileName = OutputFile;
-			
+
 			return !Errors.HasErrors;
 		}
-		
-		public bool PreprocessTemplate (string inputFile, string className, string classNamespace, 
+
+		public bool PreprocessTemplate (string inputFile, string className, string classNamespace,
 			string outputFile, Encoding encoding, out string language, out string[] references)
 		{
 			language = null;
@@ -150,7 +150,7 @@ namespace Mono.TextTemplating
 				throw new ArgumentNullException (nameof (inputFile));
 			if (string.IsNullOrEmpty (outputFile))
 				throw new ArgumentNullException (nameof (outputFile));
-			
+
 			string content;
 			try {
 				content = File.ReadAllText (inputFile);
@@ -159,21 +159,21 @@ namespace Mono.TextTemplating
 				AddError ("Could not read input file '" + inputFile + "':\n" + ex);
 				return false;
 			}
-			
+
 			string output;
 			PreprocessTemplate (inputFile, className, classNamespace, content, out language, out references, out output);
-			
+
 			try {
 				if (!Errors.HasErrors)
 					File.WriteAllText (outputFile, output, encoding);
 			} catch (IOException ex) {
 				AddError ("Could not write output file '" + outputFile + "':\n" + ex);
 			}
-			
+
 			return !Errors.HasErrors;
 		}
-		
-		public bool PreprocessTemplate (string inputFileName, string className, string classNamespace, string inputContent, 
+
+		public bool PreprocessTemplate (string inputFileName, string className, string classNamespace, string inputContent,
 			out string language, out string[] references, out string outputContent)
 		{
 			Errors.Clear ();
@@ -181,19 +181,19 @@ namespace Mono.TextTemplating
 
 			TemplateFile = inputFileName;
 			outputContent = Engine.PreprocessTemplate (inputContent, this, className, classNamespace, out language, out references);
-			
+
 			return !Errors.HasErrors;
 		}
-		
+
 		CompilerError AddError (string error)
 		{
 			var err = new CompilerError { ErrorText = error };
 			Errors.Add (err);
 			return err;
 		}
-		
+
 		#region Virtual members
-		
+
 		public virtual object GetHostOption (string optionName)
 		{
 			switch (optionName) {
@@ -202,12 +202,12 @@ namespace Mono.TextTemplating
 			}
 			return null;
 		}
-		
+
 		public virtual AppDomain ProvideTemplatingAppDomain (string content)
 		{
 			return null;
 		}
-		
+
 		protected virtual string ResolveAssemblyReference (string assemblyReference)
 		{
 			if (System.IO.Path.IsPathRooted (assemblyReference))
@@ -230,7 +230,7 @@ namespace Mono.TextTemplating
 				return assemblyReference + ".dll";
 			return assemblyReference;
 		}
-		
+
 		protected virtual string ResolveParameterValue (string directiveId, string processorName, string parameterName)
 		{
 			var key = new ParameterKey (processorName, directiveId, parameterName);
@@ -240,7 +240,7 @@ namespace Mono.TextTemplating
 				return ResolveParameterValue (null, null, parameterName);
 			return null;
 		}
-		
+
 		protected virtual Type ResolveDirectiveProcessor (string processorName)
 		{
 			if (!directiveProcessors.TryGetValue (processorName, out KeyValuePair<string, string> value))
@@ -251,7 +251,7 @@ namespace Mono.TextTemplating
 			var asm = Assembly.LoadFrom (asmPath);
 			return asm.GetType (value.Key, true);
 		}
-		
+
 		protected virtual string ResolvePath (string path)
 		{
 			if (!string.IsNullOrEmpty(path)) {
@@ -277,17 +277,17 @@ namespace Mono.TextTemplating
 
 			return path;
 		}
-		
+
 		#endregion
-		
+
 		readonly Dictionary<ParameterKey,string> parameters = new Dictionary<ParameterKey, string> ();
 		readonly Dictionary<string,KeyValuePair<string,string>> directiveProcessors = new Dictionary<string, KeyValuePair<string,string>> ();
-		
+
 		public void AddDirectiveProcessor (string name, string klass, string assembly)
 		{
 			directiveProcessors.Add (name, new KeyValuePair<string,string> (klass,assembly));
 		}
-		
+
 		public void AddParameter (string processorName, string directiveName, string parameterName, string value)
 		{
 			parameters.Add (new ParameterKey (processorName, directiveName, parameterName), value);
@@ -355,12 +355,12 @@ namespace Mono.TextTemplating
 
 			return !string.IsNullOrEmpty (name);
 		}
-		
+
 		protected virtual bool LoadIncludeText (string requestFileName, out string content, out string location)
 		{
 			content = "";
 			location = ResolvePath (requestFileName);
-			
+
 			if (location == null || !File.Exists (location)) {
 				foreach (string path in IncludePaths) {
 					string f = Path.Combine (path, requestFileName);
@@ -370,10 +370,10 @@ namespace Mono.TextTemplating
 					}
 				}
 			}
-			
+
 			if (location == null)
 				return false;
-			
+
 			try {
 				content = File.ReadAllText (location);
 				return true;
@@ -382,39 +382,39 @@ namespace Mono.TextTemplating
 			}
 			return false;
 		}
-		
+
 		#region Explicit ITextTemplatingEngineHost implementation
-		
+
 		bool ITextTemplatingEngineHost.LoadIncludeText (string requestFileName, out string content, out string location)
 		{
 			return LoadIncludeText (requestFileName, out content, out location);
 		}
-		
+
 		void ITextTemplatingEngineHost.LogErrors (CompilerErrorCollection errors)
 		{
 			this.Errors.AddRange (errors);
 		}
-		
+
 		string ITextTemplatingEngineHost.ResolveAssemblyReference (string assemblyReference)
 		{
 			return ResolveAssemblyReference (assemblyReference);
 		}
-		
+
 		string ITextTemplatingEngineHost.ResolveParameterValue (string directiveId, string processorName, string parameterName)
 		{
 			return ResolveParameterValue (directiveId, processorName, parameterName);
 		}
-		
+
 		Type ITextTemplatingEngineHost.ResolveDirectiveProcessor (string processorName)
 		{
 			return ResolveDirectiveProcessor (processorName);
 		}
-		
+
 		string ITextTemplatingEngineHost.ResolvePath (string path)
 		{
 			return ResolvePath (path);
 		}
-		
+
 		void ITextTemplatingEngineHost.SetFileExtension (string extension)
 		{
 			extension = extension.TrimStart ('.');
@@ -424,23 +424,23 @@ namespace Mono.TextTemplating
 				OutputFile = OutputFile + "." + extension;
 			}
 		}
-		
+
 		void ITextTemplatingEngineHost.SetOutputEncoding (Encoding encoding, bool fromOutputDirective)
 		{
 			this.encoding = encoding;
 		}
-		
+
 		IList<string> ITextTemplatingEngineHost.StandardAssemblyReferences {
 			get { return Refs; }
 		}
-		
+
 		IList<string> ITextTemplatingEngineHost.StandardImports {
 			get { return Imports; }
 		}
-		
-		
+
+
 		#endregion
-		
+
 		struct ParameterKey : IEquatable<ParameterKey>
 		{
 			public ParameterKey (string processorName, string directiveName, string parameterName)
@@ -454,20 +454,20 @@ namespace Mono.TextTemplating
 						^ this.parameterName.GetHashCode ();
 				}
 			}
-			
+
 			string processorName, directiveName, parameterName;
 			readonly int hashCode;
-			
+
 			public override bool Equals (object obj)
 			{
 				return obj is ParameterKey && Equals ((ParameterKey)obj);
 			}
-			
+
 			public bool Equals (ParameterKey other)
 			{
 				return processorName == other.processorName && directiveName == other.directiveName && parameterName == other.parameterName;
 			}
-			
+
 			public override int GetHashCode ()
 			{
 				return hashCode;

--- a/Mono.TextTemplating/Mono.TextTemplating/TemplateSettings.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplateSettings.cs
@@ -1,21 +1,21 @@
-// 
+//
 // TemplateSettings.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -41,7 +41,7 @@ namespace Mono.TextTemplating
 			CustomDirectives  = new List<CustomDirective> ();
 			DirectiveProcessors = new Dictionary<string, IDirectiveProcessor> ();
 		}
-		
+
 		public bool HostSpecific { get; set; }
 		public bool HostPropertyOnBase { get; set; }
 		public bool Debug { get; set; }
@@ -67,7 +67,7 @@ namespace Mono.TextTemplating
 		public Type HostType { get; set; }
 		public string GetFullName () => string.IsNullOrEmpty (Namespace) ? Name : Namespace + "." + Name;
 	}
-	
+
 	public class CustomDirective
 	{
 		public CustomDirective (string processorName, Directive directive)
@@ -75,7 +75,7 @@ namespace Mono.TextTemplating
 			ProcessorName = processorName;
 			Directive = directive;
 		}
-		
+
 		public string ProcessorName { get; set; }
 		public Directive Directive { get; set; }
 	}

--- a/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
@@ -195,7 +195,7 @@ namespace Mono.TextTemplating
 				var obj = domain.CreateInstanceFromAndUnwrap (type.Assembly.Location,
 					type.FullName,
 					new object[] { host, results, templateClassFullName, settings.Culture, references.ToArray () });
-				
+
 				return (CompiledTemplate)obj;
 			}
 #endif

--- a/Mono.TextTemplating/Mono.TextTemplating/Tokeniser.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/Tokeniser.cs
@@ -1,21 +1,21 @@
-// 
+//
 // Tokeniser.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,7 +28,7 @@ using System;
 
 namespace Mono.TextTemplating
 {
-	
+
 	public class Tokeniser
 	{
 		readonly string content;
@@ -37,14 +37,14 @@ namespace Mono.TextTemplating
 		State nextState = State.Content;
 		Location nextStateLocation;
 		Location nextStateTagStartLocation;
-		
+
 		public Tokeniser (string fileName, string content)
 		{
 			State = State.Content;
 			this.content = content;
 			this.Location = this.nextStateLocation = this.nextStateTagStartLocation = new Location (fileName, 1, 1);
 		}
-		
+
 		public bool Advance ()
 		{
 			value = null;
@@ -56,7 +56,7 @@ namespace Mono.TextTemplating
 			nextState = GetNextStateAndCurrentValue ();
 			return true;
 		}
-		
+
 		State GetNextStateAndCurrentValue ()
 		{
 			switch (State) {
@@ -64,24 +64,24 @@ namespace Mono.TextTemplating
 			case State.Expression:
 			case State.Helper:
 				return GetBlockEnd ();
-			
+
 			case State.Directive:
 				return NextStateInDirective ();
-				
+
 			case State.Content:
 				return NextStateInContent ();
-				
+
 			case State.DirectiveName:
 				return GetDirectiveName ();
-				
+
 			case State.DirectiveValue:
 				return GetDirectiveValue ();
-				
+
 			default:
 				throw new InvalidOperationException ("Unexpected state '" + State + "'");
 			}
 		}
-		
+
 		State GetBlockEnd ()
 		{
 			int start = position;
@@ -99,7 +99,7 @@ namespace Mono.TextTemplating
 					value = content.Substring (start, position - start - 1);
 					position++;
 					TagEndLocation = nextStateLocation;
-					
+
 					//skip newlines directly after blocks, unless they're expressions
 					if (State != State.Expression && (position += IsNewLine()) > 0) {
 						nextStateLocation = nextStateLocation.AddLine ();
@@ -109,7 +109,7 @@ namespace Mono.TextTemplating
 			}
 			throw new ParserException ("Unexpected end of file.", nextStateLocation);
 		}
-		
+
 		State GetDirectiveName ()
 		{
 			int start = position;
@@ -123,7 +123,7 @@ namespace Mono.TextTemplating
 			}
 			throw new ParserException ("Unexpected end of file.", nextStateLocation);
 		}
-		
+
 		State GetDirectiveValue ()
 		{
 			int start = position;
@@ -154,7 +154,7 @@ namespace Mono.TextTemplating
 			}
 			throw new ParserException ("Unexpected end of file.", nextStateLocation);
 		}
-		
+
 		State NextStateInContent ()
 		{
 			int start = position;
@@ -211,7 +211,7 @@ namespace Mono.TextTemplating
 			}
 			return found;
 		}
-		
+
 		State NextStateInDirective () {
 			for (; position < content.Length; position++) {
 				char c = content[position];
@@ -226,12 +226,12 @@ namespace Mono.TextTemplating
 				} else if (c == '=') {
 					nextStateLocation = nextStateLocation.AddCol ();
 					position++;
-					return State.DirectiveValue;	
+					return State.DirectiveValue;
 				} else if (c == '#' && position + 1 < content.Length && content[position+1] == '>') {
 					position+=2;
 					TagEndLocation = nextStateLocation.AddCols (2);
 					nextStateLocation = nextStateLocation.AddCols (3);
-					
+
 					//skip newlines directly after directives
 					if ((position += IsNewLine()) > 0) {
 						nextStateLocation = nextStateLocation.AddLine();
@@ -246,28 +246,28 @@ namespace Mono.TextTemplating
 			}
 			throw new ParserException ("Unexpected end of file.", nextStateLocation);
 		}
-		
+
 		public State State {
 			get; private set;
 		}
-		
+
 		public int Position {
 			get { return position; }
 		}
-		
+
 		public string Content {
 			get { return content; }
 		}
-		
+
 		public string Value {
 			get { return value; }
 		}
-		
+
 		public Location Location { get; private set; }
 		public Location TagStartLocation { get; private set; }
 		public Location TagEndLocation { get; private set; }
 	}
-	
+
 	public enum State
 	{
 		Content = 0,
@@ -280,14 +280,14 @@ namespace Mono.TextTemplating
 		Name,
 		EOF
 	}
-	
+
 	public class ParserException : Exception
 	{
 		public ParserException (string message, Location location) : base (message)
 		{
 			Location = location;
 		}
-		
+
 		public Location Location { get; private set; }
 	}
 }

--- a/TextTransform/Options.cs
+++ b/TextTransform/Options.cs
@@ -13,10 +13,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -37,16 +37,16 @@
 // A Getopt::Long-inspired option parsing library for C#.
 //
 // NDesk.Options.OptionSet is built upon a key/value table, where the
-// key is a option format string and the value is a delegate that is 
+// key is a option format string and the value is a delegate that is
 // invoked when the format string is matched.
 //
 // Option format strings:
-//  Regex-like BNF Grammar: 
+//  Regex-like BNF Grammar:
 //    name: .+
 //    type: [=:]
 //    sep: ( [^{}]+ | '{' .+ '}' )?
 //    aliases: ( name type sep ) ( '|' name type sep )*
-// 
+//
 // Each '|'-delimited name is an alias for the associated action.  If the
 // format string ends in a '=', it has a required value.  If the format
 // string ends in a ':', it has an optional value.  If neither '=' or ':'
@@ -92,7 +92,7 @@
 //  p.Parse (new string[]{"-v", "--v", "/v", "-name=A", "/name", "B", "extra"});
 //
 // The above would parse the argument string array, and would invoke the
-// lambda expression three times, setting `verbose' to 3 when complete.  
+// lambda expression three times, setting `verbose' to 3 when complete.
 // It would also print out "A" and "B" to standard output.
 // The returned array would contain the string "extra".
 //
@@ -208,7 +208,7 @@ namespace Mono.Options
 			if (c.Option.OptionValueType == OptionValueType.Required &&
 					index >= values.Count)
 				throw new OptionException (string.Format (
-							c.OptionSet.MessageLocalizer ("Missing required value for option '{0}'."), c.OptionName), 
+							c.OptionSet.MessageLocalizer ("Missing required value for option '{0}'."), c.OptionName),
 						c.OptionName);
 		}
 
@@ -257,7 +257,7 @@ namespace Mono.Options
 			set {option = value;}
 		}
 
-		public string OptionName { 
+		public string OptionName {
 			get {return name;}
 			set {name = value;}
 		}
@@ -277,7 +277,7 @@ namespace Mono.Options
 	}
 
 	public enum OptionValueType {
-		None, 
+		None,
 		Optional,
 		Required,
 	}
@@ -318,7 +318,7 @@ namespace Mono.Options
 				throw new ArgumentException (
 						string.Format ("Cannot provide maxValueCount of {0} for OptionValueType.None.", maxValueCount),
 						"maxValueCount");
-			if (Array.IndexOf (names, "<>") >= 0 && 
+			if (Array.IndexOf (names, "<>") >= 0 &&
 					((names.Length == 1 && this.type != OptionValueType.None) ||
 					 (names.Length > 1 && this.MaxValueCount > 1)))
 				throw new ArgumentException (
@@ -346,8 +346,8 @@ namespace Mono.Options
 		protected static T Parse<T> (string value, OptionContext c)
 		{
 			Type tt = typeof (T);
-			bool nullable = tt.IsValueType && tt.IsGenericType && 
-				!tt.IsGenericTypeDefinition && 
+			bool nullable = tt.IsValueType && tt.IsGenericType &&
+				!tt.IsGenericTypeDefinition &&
 				tt.GetGenericTypeDefinition () == typeof (Nullable<>);
 			Type targetType = nullable ? tt.GetGenericArguments () [0] : typeof (T);
 			TypeConverter conv = TypeDescriptor.GetConverter (targetType);
@@ -386,7 +386,7 @@ namespace Mono.Options
 				names [i] = name.Substring (0, end);
 				if (type == '\0' || type == name [end])
 					type = name [end];
-				else 
+				else
 					throw new ArgumentException (
 							string.Format ("Conflicting option types: '{0}' vs. '{1}'.", type, name [end]),
 							"prototype");
@@ -603,7 +603,7 @@ namespace Mono.Options
 		{
 			if (action == null)
 				throw new ArgumentNullException ("action");
-			Option p = new ActionOption (prototype, description, 1, 
+			Option p = new ActionOption (prototype, description, 1,
 					delegate (OptionValueCollection v) { action (v [0]); });
 			base.Add (p);
 			return this;
@@ -618,7 +618,7 @@ namespace Mono.Options
 		{
 			if (action == null)
 				throw new ArgumentNullException ("action");
-			Option p = new ActionOption (prototype, description, 2, 
+			Option p = new ActionOption (prototype, description, 2,
 					delegate (OptionValueCollection v) {action (v [0], v [1]);});
 			base.Add (p);
 			return this;
@@ -692,18 +692,18 @@ namespace Mono.Options
 			OptionContext c = CreateOptionContext ();
 			c.OptionIndex = -1;
 			var def = GetOptionForName ("<>");
-			var unprocessed = 
+			var unprocessed =
 				from argument in arguments
 				where ++c.OptionIndex >= 0 && (process || def != null)
 					? process
-						? argument == "--" 
+						? argument == "--"
 							? (process = false)
 							: !Parse (argument, c)
-								? def != null 
-									? Unprocessed (null, def, c, argument) 
+								? def != null
+									? Unprocessed (null, def, c, argument)
 									: true
 								: false
-						: def != null 
+						: def != null
 							? Unprocessed (null, def, c, argument)
 							: true
 					: true
@@ -796,7 +796,7 @@ namespace Mono.Options
 						c.Option.Invoke (c);
 						break;
 					case OptionValueType.Optional:
-					case OptionValueType.Required: 
+					case OptionValueType.Required:
 						ParseValue (v, c);
 						break;
 				}
@@ -815,17 +815,17 @@ namespace Mono.Options
 		private void ParseValue (string option, OptionContext c)
 		{
 			if (option != null)
-				foreach (string o in c.Option.ValueSeparators != null 
+				foreach (string o in c.Option.ValueSeparators != null
 						? option.Split (c.Option.ValueSeparators, StringSplitOptions.None)
 						: new string[]{option}) {
 					c.OptionValues.Add (o);
 				}
-			if (c.OptionValues.Count == c.Option.MaxValueCount || 
+			if (c.OptionValues.Count == c.Option.MaxValueCount ||
 					c.Option.OptionValueType == OptionValueType.Optional)
 				c.Option.Invoke (c);
 			else if (c.OptionValues.Count > c.Option.MaxValueCount) {
 				throw new OptionException (localizer (string.Format (
-								"Error: Found {0} option values when expecting {1}.", 
+								"Error: Found {0} option values when expecting {1}.",
 								c.OptionValues.Count, c.Option.MaxValueCount)),
 						c.OptionName);
 			}
@@ -933,7 +933,7 @@ namespace Mono.Options
 				Write (o, ref written, names [0]);
 			}
 
-			for ( i = GetNextOptionIndex (names, i+1); 
+			for ( i = GetNextOptionIndex (names, i+1);
 					i < names.Length; i = GetNextOptionIndex (names, i+1)) {
 				Write (o, ref written, ", ");
 				Write (o, ref written, names [i].Length == 1 ? "-" : "--");
@@ -946,7 +946,7 @@ namespace Mono.Options
 					Write (o, ref written, localizer ("["));
 				}
 				Write (o, ref written, localizer ("=" + GetArgumentName (0, p.MaxValueCount, p.Description)));
-				string sep = p.ValueSeparators != null && p.ValueSeparators.Length > 0 
+				string sep = p.ValueSeparators != null && p.ValueSeparators.Length > 0
 					? p.ValueSeparators [0]
 					: " ";
 				for (int c = 1; c < p.MaxValueCount; ++c) {

--- a/TextTransform/TextTransform.cs
+++ b/TextTransform/TextTransform.cs
@@ -1,21 +1,21 @@
-// 
+//
 // Main.cs
-//  
+//
 // Author:
 //       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
-// 
+//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -52,13 +52,13 @@ namespace Mono.TextTemplating
 			if (args.Length == 0) {
 				ShowHelp (true);
 			}
-			
+
 			var generator = new TemplateGenerator ();
 			string outputFile = null, inputFile = null;
 			var directives = new List<string> ();
 			var parameters = new List<string> ();
 			string preprocess = null;
-			
+
 			optionSet = new OptionSet () {
 				{ "o=|out=", "The name of the output {file}", s => outputFile = s },
 				{ "r=", "Assemblies to reference", s => generator.Refs.Add (s) },
@@ -71,20 +71,20 @@ namespace Mono.TextTemplating
 		//		{ "k=,", "Session {key},{value} pairs", (s, t) => session.Add (s, t) },
 				{ "c=", "Preprocess the template into {0:class}", (s) => preprocess = s },
 			};
-			
+
 			var remainingArgs = optionSet.Parse (args);
-			
+
 			if (remainingArgs.Count != 1) {
 				Console.Error.WriteLine ("No input file specified.");
 				return -1;
 			}
 			inputFile = remainingArgs [0];
-			
+
 			if (!File.Exists (inputFile)) {
 				Console.Error.WriteLine ("Input file '{0}' does not exist.", inputFile);
 				return -1;
 			}
-			
+
 			if (string.IsNullOrEmpty (outputFile)) {
 				outputFile = inputFile;
 				if (Path.HasExtension (outputFile)) {
@@ -102,7 +102,7 @@ namespace Mono.TextTemplating
 					return -1;
 				}
 			}
-			
+
 			foreach (var dir in directives) {
 				var split = dir.Split ('!');
 
@@ -122,7 +122,7 @@ namespace Mono.TextTemplating
 
 				generator.AddDirectiveProcessor (split[0], split[1], split[2]);
 			}
-			
+
 			if (preprocess == null) {
 				generator.ProcessTemplate (inputFile, outputFile);
 				if (generator.Errors.HasErrors) {
@@ -136,21 +136,21 @@ namespace Mono.TextTemplating
 					classNamespace = preprocess.Substring (0, s);
 					className = preprocess.Substring (s + 1);
 				}
-				
+
 				generator.PreprocessTemplate (inputFile, className, classNamespace, outputFile, System.Text.Encoding.UTF8,
 					out string language, out string[] references);
 				if (generator.Errors.HasErrors) {
 					Console.Write ("Preprocessing '{0}' into class '{1}.{2}' failed.", inputFile, classNamespace, className);
 				}
 			}
-			
+
 			foreach (System.CodeDom.Compiler.CompilerError err in generator.Errors)
 				Console.Error.WriteLine ("{0}({1},{2}): {3} {4}", err.FileName, err.Line, err.Column,
 				                   err.IsWarning? "WARNING" : "ERROR", err.ErrorText);
-			
+
 			return generator.Errors.HasErrors? -1 : 0;
 		}
-		
+
 		static void ShowHelp (bool concise)
 		{
 			Console.WriteLine ("TextTransform command line T4 processor");

--- a/dotnet-t4/TextTransform.cs
+++ b/dotnet-t4/TextTransform.cs
@@ -1,17 +1,17 @@
-﻿// 
+﻿//
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
 // Copyright (c) Microsoft Corp. (https://www.microsoft.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE


### PR DESCRIPTION
The `.editorconfig` says `trim_trailing_whitespace = true`:

https://github.com/mono/t4/blob/a80187de88cf5705aa454894b80c283b14212a6c/.editorconfig#L6-L10

This PR applies the rule to all files to avoid unrelated noise in future commits.
