### PR TITLE
Use BOM-less UTF8 encoding

### DIFF
--- a/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
@@ -86,7 +86,7 @@ namespace Mono.TextTemplating
 				throw new ArgumentNullException (nameof (content));
 
 			Errors.Clear ();
-			encoding = Encoding.UTF8;
+			encoding = Utf8.BomlessEncoding;
 			
 			return Engine.CompileTemplate (content, this);
 		}
@@ -130,7 +130,7 @@ namespace Mono.TextTemplating
 		public bool ProcessTemplate (string inputFileName, string inputContent, ref string outputFileName, out string outputContent)
 		{
 			Errors.Clear ();
-			encoding = Encoding.UTF8;
+			encoding = Utf8.BomlessEncoding;
 
 			OutputFile = outputFileName;
 			TemplateFile = inputFileName;
@@ -177,7 +177,7 @@ namespace Mono.TextTemplating
 			out string language, out string[] references, out string outputContent)
 		{
 			Errors.Clear ();
-			encoding = Encoding.UTF8;
+			encoding = Utf8.BomlessEncoding;
 
 			TemplateFile = inputFileName;
 			outputContent = Engine.PreprocessTemplate (inputContent, this, className, classNamespace, out language, out references);

--- a/Mono.TextTemplating/Mono.TextTemplating/Utf8.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/Utf8.cs
@@ -1,0 +1,35 @@
+//
+// Utf8.cs
+//
+// Author:
+//       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
+//
+// Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Text;
+
+namespace Mono.TextTemplating
+{
+	static class Utf8
+	{
+		public static Encoding BomlessEncoding = new UTF8Encoding (encoderShouldEmitUTF8Identifier: false);
+	}
+}

--- a/Mono.TextTemplating/Mono.TextTemplating/Utf8.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/Utf8.cs
@@ -2,9 +2,9 @@
 // Utf8.cs
 //
 // Author:
-//       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
+//       Atif Aziz
 //
-// Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
+// Copyright (c) 2019 Atif Aziz
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/TextTransform/TextTransform.cs
+++ b/TextTransform/TextTransform.cs
@@ -136,8 +136,8 @@ namespace Mono.TextTemplating
 					classNamespace = preprocess.Substring (0, s);
 					className = preprocess.Substring (s + 1);
 				}
-				
-				generator.PreprocessTemplate (inputFile, className, classNamespace, outputFile, System.Text.Encoding.UTF8,
+
+				generator.PreprocessTemplate (inputFile, className, classNamespace, outputFile, new System.Text.UTF8Encoding (encoderShouldEmitUTF8Identifier: false),
 					out string language, out string[] references);
 				if (generator.Errors.HasErrors) {
 					Console.Write ("Preprocessing '{0}' into class '{1}.{2}' failed.", inputFile, classNamespace, className);

--- a/dotnet-t4/TextTransform.cs
+++ b/dotnet-t4/TextTransform.cs
@@ -226,7 +226,7 @@ namespace Mono.TextTemplating
 					if (writeToStdout) {
 						Console.WriteLine (outputContent);
 					} else {
-						File.WriteAllText (outputFile, outputContent, Encoding.UTF8);
+						File.WriteAllText (outputFile, outputContent, new UTF8Encoding (encoderShouldEmitUTF8Identifier: false));
 					}
 				}
 			}


### PR DESCRIPTION
This PR avoids the BOM marker when encoding files in UTF-8 because it's annoying. :)