### PR TITLE
Change naming of the autogenerated class and namespace to match those of VS

### DIFF
--- a/Mono.TextTemplating.Tests/GenerationTests.cs
+++ b/Mono.TextTemplating.Tests/GenerationTests.cs
@@ -109,8 +109,8 @@ namespace Mono.TextTemplating.Tests
 		void Generate (string input, string expectedOutput, string newline)
 		{
 			DummyHost host = new DummyHost ();
-			string className = "GeneratedTextTransformation4f504ca0";
-			string code = GenerateCode (host, input, className, newline);
+			string nameSpaceName = "Microsoft.VisualStudio.TextTemplating4f504ca0";
+			string code = GenerateCode (host, input, nameSpaceName, newline);
 			Assert.AreEqual (0, host.Errors.Count);
 
 			var generated = TemplatingEngineHelper.CleanCodeDom (code, newline);
@@ -130,7 +130,7 @@ namespace Mono.TextTemplating.Tests
 			
 			TemplateSettings settings = TemplatingEngine.GetSettings (host, pt);
 			if (name != null)
-				settings.Name = name;
+				settings.Namespace = name;
 			if (pt.Errors.HasErrors) {
 				host.LogErrors (pt.Errors);
 				return null;
@@ -156,10 +156,10 @@ namespace Mono.TextTemplating.Tests
 
 		public static string OutputSample1 =
 @"
-namespace Microsoft.VisualStudio.TextTemplating {
+namespace Microsoft.VisualStudio.TextTemplating4f504ca0 {
     
     
-    public partial class GeneratedTextTransformation4f504ca0 : global::Microsoft.VisualStudio.TextTemplating.TextTransformation {
+    public partial class GeneratedTextTransformation : global::Microsoft.VisualStudio.TextTemplating.TextTransformation {
         
         
         #line 9 """"

--- a/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
@@ -436,9 +436,9 @@ namespace Mono.TextTemplating
 			}
 
 			if (settings.Name == null)
-				settings.Name = string.Format ("GeneratedTextTransformation{0:x}", new Random ().Next ());
+				settings.Name = "GeneratedTextTransformation";
 			if (settings.Namespace == null)
-				settings.Namespace = typeof (TextTransformation).Namespace;
+				settings.Namespace = string.Format (typeof (TextTransformation).Namespace + "{0:x}", new Random ().Next ());
 
 			//resolve the CodeDOM provider
 			if (String.IsNullOrEmpty (settings.Language)) {


### PR DESCRIPTION
Many T4 templates (see for example [Linq2db](https://github.com/linq2db/linq2db/tree/master/Source/LinqToDB.Templates)) use the name of the auto-generated class to extend its functionality. This PR changes the naming of the auto-generated class and namespace to match those of VS to allow such templates to correctly compile under Mono.