### PR TITLE
GH64: Add support SemVer for .NET Core SDK/Runtime

### DIFF
--- a/Mono.TextTemplating.Tests/SemVersionTests.cs
+++ b/Mono.TextTemplating.Tests/SemVersionTests.cs
@@ -1,0 +1,147 @@
+//
+// Copyright (c) Microsoft Corp (https://www.microsoft.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Linq;
+using Mono.TextTemplating.CodeCompilation;
+using NUnit.Framework;
+
+namespace Mono.TextTemplating.Tests
+{
+	[TestFixture]
+	public class SemVersionTests
+	{
+		[TestCase ("2.1.801", 2, 1, 801, null, null)]
+		[TestCase ("2.1.12", 2, 1, 12, null, null)]
+		[TestCase ("2.1.700", 2, 1, 700, null, null)]
+		[TestCase ("2.1.604", 2, 1, 604, null, null)]
+		[TestCase ("2.1.11", 2, 1, 11, null, null)]
+		[TestCase ("2.1.603", 2, 1, 603, null, null)]
+		[TestCase ("2.1.10", 2, 1, 10, null, null)]
+		[TestCase ("2.1.602", 2, 1, 602, null, null)]
+		[TestCase ("2.1.9", 2, 1, 9, null, null)]
+		[TestCase ("2.1.8", 2, 1, 8, null, null)]
+		[TestCase ("2.1.7", 2, 1, 7, null, null)]
+		[TestCase ("2.1.502", 2, 1, 502, null, null)]
+		[TestCase ("2.1.600-preview", 2, 1, 600, "preview", null)]
+		[TestCase ("2.1.6", 2, 1, 6, null, null)]
+		[TestCase ("2.1.5", 2, 1, 5, null, null)]
+		[TestCase ("2.1.4", 2, 1, 4, null, null)]
+		[TestCase ("2.1.3", 2, 1, 3, null, null)]
+		[TestCase ("2.1.2", 2, 1, 2, null, null)]
+		[TestCase ("2.1.1", 2, 1, 1, null, null)]
+		[TestCase ("2.1.0", 2, 1, 0, null, null)]
+		[TestCase ("2.1.0-rc1", 2, 1, 0, "rc1", null)]
+		[TestCase ("2.1.0-preview2", 2, 1, 0, "preview2", null)]
+		[TestCase ("2.1.0-preview1", 2, 1, 0, "preview1", null)]
+		[TestCase ("3.0.0-preview9", 3, 0, 0, "preview9", null)]
+		[TestCase ("3.0.0-preview8+build.1", 3, 0, 0, "preview8", "build.1")]
+        [TestCase ("3.0.0-preview8+build.2", 3, 0, 0, "preview8", "build.2")]
+		[TestCase ("3.0.0-preview7", 3, 0, 0, "preview7", null)]
+		[TestCase ("3.0.0-preview6", 3, 0, 0, "preview6", null)]
+		[TestCase ("3.0.0-preview5", 3, 0, 0, "preview5", null)]
+		[TestCase ("3.0.0-preview4", 3, 0, 0, "preview4", null)]
+		[TestCase ("3.0.0-preview3", 3, 0, 0, "preview3", null)]
+		[TestCase ("3.0.0-preview2", 3, 0, 0, "preview2", null)]
+		[TestCase ("3.0.0-preview1", 3, 0, 0, "preview1", null)]
+		public void TryParse (string version, int expectMajor, int expectMinor, int expectPatch, string expectPreRelease, string expectedMeta)
+		{
+			var parsed = SemVersion.TryParse (version, out SemVersion semVersion);
+            Assert.True(parsed);
+			Assert.AreEqual(version, semVersion.VersionString, nameof(semVersion.VersionString));
+			Assert.AreEqual (expectMajor, semVersion.Major, nameof (semVersion.Major));
+			Assert.AreEqual (expectMinor, semVersion.Minor, nameof (semVersion.Minor));
+			Assert.AreEqual (expectPatch, semVersion.Patch, nameof (semVersion.Patch));
+			Assert.AreEqual (expectPreRelease, semVersion.PreRelease, nameof (semVersion.PreRelease));
+			Assert.AreEqual (expectedMeta, semVersion.Meta, nameof (semVersion.Meta));
+		}
+
+		[Test]
+		public void Compare()
+		{
+			var given = new[] {
+				"3.0.0-preview9",
+				"3.0.0-preview8",
+				"3.0.0-preview7",
+				"3.0.0-preview6",
+				"3.0.0-preview5",
+				"3.0.0-preview4",
+				"3.0.0-preview3",
+				"3.0.0-preview2",
+				"3.0.0-preview1+build.4",
+				"3.0.0-preview1+build.3",
+				"3.0.0-preview1+build.2",
+				"3.0.0-preview1+build.1",
+				"3.0.0-preview1",
+				"2.2.6",
+				"2.2.300",
+				"2.2.204",
+				"2.2.5",
+				"2.2.203",
+				"2.2.4",
+				"2.2.202",
+				"2.2.3",
+				"2.2.2",
+				"2.2.103",
+				"2.2.1",
+				"2.2.101",
+				"2.2.200-preview"
+			};
+
+			var expect = new[] {
+	            "2.2.1",
+	            "2.2.2",
+	            "2.2.3",
+	            "2.2.4",
+	            "2.2.5",
+	            "2.2.6",
+	            "2.2.101",
+	            "2.2.103",
+	            "2.2.200-preview",
+	            "2.2.202",
+	            "2.2.203",
+	            "2.2.204",
+	            "2.2.300",
+	            "3.0.0-preview1",
+	            "3.0.0-preview1+build.1",
+	            "3.0.0-preview1+build.2",
+	            "3.0.0-preview1+build.3",
+	            "3.0.0-preview1+build.4",
+	            "3.0.0-preview2",
+	            "3.0.0-preview3",
+	            "3.0.0-preview4",
+	            "3.0.0-preview5",
+	            "3.0.0-preview6",
+	            "3.0.0-preview7",
+	            "3.0.0-preview8",
+	            "3.0.0-preview9"
+			};
+
+			var actual = given
+				.Select (
+					version => SemVersion.TryParse (version, out var semVersion) ? semVersion : SemVersion.Zero)
+				.OrderBy (semVersion => semVersion)
+				.Select(semVersion => semVersion.VersionString)
+				.ToArray ();
+
+			Assert.AreEqual (expect, actual);
+		}
+	}
+}

--- a/Mono.TextTemplating/Mono.TextTemplating.CodeCompilation/RuntimeInfo.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating.CodeCompilation/RuntimeInfo.cs
@@ -131,10 +131,10 @@ namespace Mono.TextTemplating.CodeCompilation
 		static string FindHighestVersionedDirectory (string parentFolder, Func<string, bool> validate)
 		{
 			string bestMatch = null;
-			var bestVersion = new Version(0, 0, 0);
+			var bestVersion = SemVersion.Zero;
 			foreach (var dir in Directory.EnumerateDirectories (parentFolder)) {
 				var name = Path.GetFileName (dir);
-				if (Version.TryParse (name, out var version) && version.Build >= 0) {
+				if (SemVersion.TryParse (name, out var version) && version.Major >= 0) {
 					if (version > bestVersion && (validate == null || validate (dir))) {
 						bestVersion = version;
 						bestMatch = dir;

--- a/Mono.TextTemplating/Mono.TextTemplating.CodeCompilation/SemVersion.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating.CodeCompilation/SemVersion.cs
@@ -1,0 +1,222 @@
+//
+// Copyright (c) Microsoft Corp (https://www.microsoft.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Mono.TextTemplating.CodeCompilation
+{
+	public struct SemVersion : IComparable, IComparable<SemVersion>, IEquatable<SemVersion>
+	{
+        public static SemVersion Zero { get; } = new SemVersion(0,0,0, null, null, "0.0.0");
+
+		static readonly Regex SemVerRegex =
+			new Regex (
+				@"(?<Major>0|(?:[1-9]\d*))(?:\.(?<Minor>0|(?:[1-9]\d*))(?:\.(?<Patch>0|(?:[1-9]\d*)))?(?:\-(?<PreRelease>[0-9A-Z\.-]+))?(?:\+(?<Meta>[0-9A-Z\.-]+))?)?",
+				RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase
+			);
+
+
+		public int Major { get; }
+		public int Minor { get; }
+		public int Patch { get; }
+		public string PreRelease { get; }
+		public string Meta { get; }
+        public bool IsPreRelease { get; }
+        public bool HasMeta { get; }
+        public string VersionString { get; }
+
+        public SemVersion (int major, int minor, int patch, string preRelease = null, string meta = null) :
+	        this (major, minor, patch, preRelease, meta, null)
+        {
+        }
+
+        SemVersion (int major, int minor, int patch, string preRelease, string meta, string versionString)
+		{
+			Major = major;
+			Minor = minor;
+			Patch = patch;
+			IsPreRelease = !string.IsNullOrEmpty (preRelease);
+			HasMeta = !string.IsNullOrEmpty (meta);
+			PreRelease = IsPreRelease ? preRelease : null;
+			Meta = HasMeta ? meta : null;
+
+			if (!string.IsNullOrEmpty (versionString)) {
+				VersionString = versionString;
+			} else {
+				var sb = new StringBuilder ();
+				sb.AppendFormat (CultureInfo.InvariantCulture, "{0}.{1}.{2}", Major, Minor, Patch);
+
+				if (IsPreRelease) {
+					sb.AppendFormat (CultureInfo.InvariantCulture, "-{0}", PreRelease);
+				}
+
+				if (HasMeta) {
+					sb.AppendFormat (CultureInfo.InvariantCulture, "+{0}", Meta);
+				}
+
+				VersionString = sb.ToString ();
+			}
+		}
+
+		public static bool TryParse (string version, out SemVersion semVersion)
+		{
+			semVersion = Zero;
+
+			if (string.IsNullOrEmpty(version)) {
+				return false;
+			}
+
+			var match = SemVerRegex.Match (version);
+			if (!match.Success) {
+				return false;
+			}
+
+			if (!int.TryParse (
+				    match.Groups["Major"].Value,
+				    NumberStyles.Integer,
+				    CultureInfo.InvariantCulture,
+				    out var major) ||
+			    !int.TryParse (
+				    match.Groups["Minor"].Value,
+				    NumberStyles.Integer,
+				    CultureInfo.InvariantCulture,
+				    out var minor) ||
+			    !int.TryParse (
+				    match.Groups["Patch"].Value,
+				    NumberStyles.Integer,
+				    CultureInfo.InvariantCulture,
+				    out var patch)) {
+				return false;
+			}
+
+			semVersion = new SemVersion (
+				major,
+				minor,
+				patch,
+				match.Groups["PreRelease"]?.Value,
+				match.Groups["Meta"]?.Value,
+				version);
+
+			return true;
+		}
+
+		
+
+		public bool Equals (SemVersion other)
+		{
+			return Major == other.Major
+			       && Minor == other.Minor
+			       && Patch == other.Patch
+			       && string.Equals(PreRelease, other.PreRelease, StringComparison.OrdinalIgnoreCase)
+			       && string.Equals(Meta, other.Meta, StringComparison.OrdinalIgnoreCase);
+		}
+
+		public int CompareTo (SemVersion other)
+		{
+			if (Equals(other))
+			{
+				return 0;
+			}
+
+			if (Major > other.Major) {
+				return 1;
+			}
+
+			if (Major < other.Major) {
+				return -1;
+			}
+
+			if (Minor > other.Minor) {
+				return 1;
+			}
+
+			if (Minor < other.Minor) {
+				return -1;
+			}
+
+			if (Patch > other.Patch) {
+				return 1;
+			}
+
+			if (Patch < other.Patch) {
+				return -1;
+			}
+
+            switch(StringComparer.InvariantCultureIgnoreCase.Compare(PreRelease, other.PreRelease)) {
+				case 1:
+					return 1;
+
+				case -1:
+					return -1;
+
+                default:
+	                return StringComparer.InvariantCultureIgnoreCase.Compare (Meta, other.Meta);
+			}
+		}
+
+		public int CompareTo (object obj)
+		{
+			return (obj is SemVersion semVersion)
+                ? CompareTo (semVersion)
+				: -1;
+		}
+
+		public override bool Equals (object obj)
+		{
+			return (obj is SemVersion semVersion)
+			       && Equals (semVersion);
+		}
+
+		public override int GetHashCode ()
+		{
+			unchecked {
+				var hashCode = Major;
+				hashCode = (hashCode * 397) ^ Minor;
+				hashCode = (hashCode * 397) ^ Patch;
+				hashCode = (hashCode * 397) ^ (PreRelease != null ? StringComparer.OrdinalIgnoreCase.GetHashCode (PreRelease) : 0);
+				hashCode = (hashCode * 397) ^ (Meta != null ? StringComparer.OrdinalIgnoreCase.GetHashCode (Meta) : 0);
+				return hashCode;
+			}
+		}
+
+		public override string ToString ()
+			=> VersionString;
+
+		// Define the is greater than operator.
+		public static bool operator > (SemVersion operand1, SemVersion operand2)
+            => operand1.CompareTo (operand2) == 1;
+
+		// Define the is less than operator.
+		public static bool operator < (SemVersion operand1, SemVersion operand2)
+			=> operand1.CompareTo (operand2) == -1;
+
+		// Define the is greater than or equal to operator.
+		public static bool operator >= (SemVersion operand1, SemVersion operand2)
+			=> operand1.CompareTo (operand2) >= 0;
+
+		// Define the is less than or equal to operator.
+		public static bool operator <= (SemVersion operand1, SemVersion operand2)
+			=> operand1.CompareTo (operand2) <= 0;
+	}
+}


### PR DESCRIPTION
* fixes #64

Had a 7 tests (GenerationTests / ParsingTests) fail, but fairly sure those are unrelated as they're in areas I've not changed anything(tried to be as focused / change as little as possible)). Could be something locally with my environment.


