### PR TITLE
Fix null filePath parameter in CompileFile when Debug is true.

### DIFF
--- a/Mono.TextTemplating.Roslyn/RoslynCodeCompiler.cs
+++ b/Mono.TextTemplating.Roslyn/RoslynCodeCompiler.cs
@@ -52,7 +52,6 @@ namespace Mono.TextTemplating
 
 			EmitOptions emitOptions = null;
 			if (arguments.Debug) {
-				var embeddedTexts = syntaxTrees.Select (st => EmbeddedText.FromSource (st.FilePath, st.GetText ())).ToList ();
 				emitOptions = new EmitOptions (debugInformationFormat: DebugInformationFormat.Embedded);
 			}
 


### PR DESCRIPTION
EmbeddedText.FromSource is throwing an exception when the SyntaxTree.FilePath is null.  In this case, FilePath is always null, so if the template directives have debug="true" then the line I removed is causing an exception to be thrown stating the filePath parameter is null.  The embeddedTexts variable doesn't seem to be used anyway, so I don't believe it's necessary.  Perhaps left-over debug code?