### PR TITLE
Support resolving assembly from loaded assemblies and little support for vs macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Thumbs.db
 
 # dotCover
 *.dotCover
+/dotnet-t4/Properties/launchSettings.json

--- a/Mono.TextTemplating/Mono.TextTemplating/CompiledTemplate.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/CompiledTemplate.cs
@@ -160,6 +160,7 @@ namespace Mono.TextTemplating
 			if (host != null) {
 				host = null;
 				AppDomain.CurrentDomain.AssemblyResolve -= ResolveReferencedAssemblies;
+				AppDomain.CurrentDomain.AssemblyLoad -= CacheOnAssemblyLoad;
 			}
 		}
 	}

--- a/Mono.TextTemplating/Mono.TextTemplating/FileUtil.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/FileUtil.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // FileUtil.cs
 //
 // Author:
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 using System;
 using System.IO;
+using System.Linq;
 
 namespace Mono.TextTemplating
 {
@@ -105,6 +106,27 @@ namespace Mono.TextTemplating
 				}
 				return new string (result);
 			}
+		}
+
+		/// <summary>
+		/// Find the projet that contains the file
+		/// </summary>
+		/// <param name="childFile"></param>
+		/// <param name="projectFile">Full path to project file</param>
+		/// <returns></returns>
+		public static bool TryFindProjectFile (string childFile, out string projectFile)
+		{
+			string directory = Path.GetDirectoryName (Path.GetFullPath(childFile));
+			while (Directory.Exists (directory) && Directory.GetDirectoryRoot (directory) != directory) {
+				var files = Directory.GetFiles (directory, "*.*proj").ToList();
+				if (files.Any ()) {
+					projectFile = files.First ();
+					return true;
+				}
+				directory = Path.GetDirectoryName (directory);
+			}
+			projectFile = null;
+			return false;
 		}
 
 		static bool IsSeparator (char ch)

--- a/Mono.TextTemplating/Mono.TextTemplating/ProjectMetadata.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/ProjectMetadata.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mono.TextTemplating
+{
+	public class ProjectMetadata
+	{
+		public Dictionary<string, string> Metadatas = new Dictionary<string, string> ();
+
+		public string ProjectDir => Metadatas[nameof (ProjectDir)];
+		public string ProjectFileName => Metadatas[nameof (ProjectFileName)];
+	}
+}

--- a/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
@@ -48,12 +48,16 @@ namespace Mono.TextTemplating
 			{ "System.Linq.dll", typeof(System.Linq.Enumerable).Assembly.Location },
 			{ "System.Xml.dll", typeof(System.Xml.XmlAttribute).Assembly.Location },
 			{ "System.Xml.Linq.dll", typeof(System.Xml.Linq.XDocument).Assembly.Location },
+			{ "System.Runtime.dll", typeof (int).Assembly.Location},
+			{ "System.ComponentModel.Primitives.dll", typeof (System.ComponentModel.DescriptionAttribute).Assembly.Location},
 
 			{ "System.Core", typeof(System.Linq.Enumerable).Assembly.Location },
 			{ "System.Data", typeof(System.Data.DataTable).Assembly.Location },
 			{ "System.Linq", typeof(System.Linq.Enumerable).Assembly.Location },
 			{ "System.Xml", typeof(System.Xml.XmlAttribute).Assembly.Location },
-			{ "System.Xml.Linq", typeof(System.Xml.Linq.XDocument).Assembly.Location }
+			{ "System.Xml.Linq", typeof(System.Xml.Linq.XDocument).Assembly.Location },
+			{ "System.Runtime", typeof (int).Assembly.Location},
+			{ "System.ComponentModel.Primitives", typeof (System.ComponentModel.DescriptionAttribute).Assembly.Location},
 		};
 
 		//re-usable

--- a/dotnet-t4/ToolTemplateGenerator.cs
+++ b/dotnet-t4/ToolTemplateGenerator.cs
@@ -42,6 +42,7 @@ namespace Mono.TextTemplating
 			TemplateSettings settings = null)
 		{
 			TemplateFile = inputFile;
+			BuildProjectMetadata ();
 			string classNamespace = null;
 			int s = className.LastIndexOf ('.');
 			if (s > 0) {
@@ -61,6 +62,7 @@ namespace Mono.TextTemplating
 		{
 			TemplateFile = inputFile;
 			OutputFile = outputFile;
+			BuildProjectMetadata ();
 			using (var compiled = Engine.CompileTemplate (pt, inputContent, this, settings)) {
 				var result = compiled?.Process ();
 				outputFile = OutputFile;

--- a/dotnet-t4/dotnet-t4.csproj
+++ b/dotnet-t4/dotnet-t4.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Some enhancement:
1. Support resolving assembly from loaded assemblies
user case: User may call Assembly.Load() in .tt file

1. Support vs macros
user case: User may call Host.ResolvePath("$(ProjectDir)") in .tt file