### PR TITLE
Fix race condition in temporary folder creation and clean it up on success

### DIFF
--- a/Mono.TextTemplating/Mono.TextTemplating/CompiledTemplate.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/CompiledTemplate.cs
@@ -56,10 +56,7 @@ namespace Mono.TextTemplating
 
 		void Load (CompilerResults results, string fullName)
 		{
-			//results.CompiledAssembly doesn't work on .NET core, it throws a cryptic internal error
-			//use Assembly.LoadFile instead
-			var assembly = System.Reflection.Assembly.LoadFile (results.PathToAssembly);
-			Type transformType = assembly.GetType (fullName);
+			Type transformType = results.CompiledAssembly.GetType (fullName);
 			//MS Templating Engine does not look on the type itself, 
 			//it checks only that required methods are exists in the compiled type 
 			textTransformation = Activator.CreateInstance (transformType);

--- a/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
@@ -236,8 +236,12 @@ namespace Mono.TextTemplating
 			// this may throw, so do it before writing source files
 			var compiler = GetOrCreateCompiler ();
 
-			var tempFolder = Path.GetTempFileName ();
-			File.Delete (tempFolder);
+			// GetTempFileName guarantees that the returned file name is unique, but
+			// there are no equivalent for directories, so we create a directory
+			// based on the file name, which *should* be unique as long as the file
+			// exists.
+			var tempFile = Path.GetTempFileName ();
+			var tempFolder = tempFile + "dir";
 			Directory.CreateDirectory (tempFolder);
 
 			if (settings.Log != null) {
@@ -286,7 +290,9 @@ namespace Mono.TextTemplating
 
 			if (!args.Debug && !r.Errors.HasErrors) {
 				r.TempFiles.Delete ();
+				// we can delete our temporary file after our temporary folder is deleted.
 				Directory.Delete (tempFolder);
+				File.Delete (tempFile);
 			}
 
 			return r;

--- a/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
@@ -274,17 +274,19 @@ namespace Mono.TextTemplating
 			r.Errors.AddRange (result.Errors.Select (e => new CompilerError (e.Origin ?? "", e.Line, e.Column, e.Code, e.Message) { IsWarning = !e.IsError }).ToArray ());
 
 			if (result.Success) {
-				r.TempFiles.AddFile (args.OutputPath, true);
+				r.TempFiles.AddFile (args.OutputPath, args.Debug);
 				if (args.Debug) {
 					r.TempFiles.AddFile (Path.ChangeExtension (args.OutputPath, ".pdb"), true);
 				}
-				r.PathToAssembly = args.OutputPath;
+				// load the assembly in memory so we can fully clean our temporary folder
+				r.CompiledAssembly = Assembly.Load (File.ReadAllBytes (args.OutputPath));
 			} else if (!r.Errors.HasErrors) {
 				r.Errors.Add (new CompilerError (null, 0, 0, null, $"The compiler exited with code {result.ExitCode}"));
 			}
 
 			if (!args.Debug && !r.Errors.HasErrors) {
 				r.TempFiles.Delete ();
+				Directory.Delete (tempFolder);
 			}
 
 			return r;


### PR DESCRIPTION
This PR fixes a race condition that can happen during the creation of the temporary folder for compilation. This can occur when processing many templates in parallel (whether in or out of process), especially on Windows where `Path.GetTempFileName` is not very random. The chosen fix is to create a temporary folder with a name based on the temporary file name and keep the file around as long as the folder exists.

This PR also cleans up the temporary folder once compilation is successful (unless template debugging is requested). In order to achieve that on Windows, the assembly needs to be loaded in memory with `Assembly.Load(byte[] rawAssembly)` instead of `Assembly.LoadFile(string path)`. The loading is now done in `TemplatingEngine.CompileCode`, where the temporary folder is created.