### PR TITLE
Support VS Mac 17.x

### DIFF
--- a/Mono.TextTemplating.Roslyn/RoslynCodeCompiler.cs
+++ b/Mono.TextTemplating.Roslyn/RoslynCodeCompiler.cs
@@ -53,14 +53,11 @@ namespace Mono.TextTemplating
 			var parseOptions = args?.ParseOptions ?? new CSharpParseOptions();
 
 			if (arguments.LangVersion != null) {
-				if (LanguageVersionFacts.TryParse(arguments.LangVersion, out var langVersion)) {
-					parseOptions = parseOptions.WithLanguageVersion (langVersion);
-				} else {
-					throw new System.Exception($"Unknown value '{arguments.LangVersion}' for langversion");
-				}
+				parseOptions = WithLanguageVersion (parseOptions, arguments.LangVersion);
 			} else {
 				// need to update this when updating referenced roslyn binaries
-				CSharpLangVersionHelper.GetBestSupportedLangVersion (runtime, CSharpLangVersion.v9_0);
+				var langVersion = CSharpLangVersionHelper.GetBestSupportedLangVersion (runtime, CSharpLangVersion.v9_0);
+				parseOptions = WithLanguageVersion (parseOptions, CSharpLangVersionHelper.ToString (langVersion));
 			}
 
 			var syntaxTrees = new List<SyntaxTree> ();
@@ -119,6 +116,15 @@ namespace Mono.TextTemplating
 				Output = new List<string> (),
 				Errors = errors
 			};
+		}
+
+		static CSharpParseOptions WithLanguageVersion (CSharpParseOptions parseOptions, string langVersionText)
+		{
+			if (LanguageVersionFacts.TryParse (langVersionText, out var langVersion)) {
+				return parseOptions.WithLanguageVersion (langVersion);
+			} else {
+				throw new System.Exception ($"Unknown value '{langVersionText}' for langversion");
+			}
 		}
 	}
 }

--- a/Mono.TextTemplating.Roslyn/TemplatingEngineExtension.cs
+++ b/Mono.TextTemplating.Roslyn/TemplatingEngineExtension.cs
@@ -11,7 +11,6 @@ namespace Mono.TextTemplating
 			engine.SetCompilerFunc ((RuntimeInfo r) => new RoslynCodeCompiler (r));
 
 			RuntimeInfo.ThrowOnMissingDotNetCoreSdkDirectory = false;
-			RuntimeInfo.DefaultMaxSupportedLangVersion = CSharpLangVersion.v9_0;
 		}
 
 		public static void UseInProcessCompiler (this TemplateGenerator generator)

--- a/Mono.TextTemplating.Roslyn/TemplatingEngineExtension.cs
+++ b/Mono.TextTemplating.Roslyn/TemplatingEngineExtension.cs
@@ -9,6 +9,9 @@ namespace Mono.TextTemplating
 		public static void UseInProcessCompiler (this TemplatingEngine engine)
 		{
 			engine.SetCompilerFunc ((RuntimeInfo r) => new RoslynCodeCompiler (r));
+
+			RuntimeInfo.ThrowOnMissingDotNetCoreSdkDirectory = false;
+			RuntimeInfo.DefaultMaxSupportedLangVersion = CSharpLangVersion.v9_0;
 		}
 
 		public static void UseInProcessCompiler (this TemplateGenerator generator)

--- a/Mono.TextTemplating/Mono.TextTemplating.CodeCompilation/CSharpLangVersionHelper.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating.CodeCompilation/CSharpLangVersionHelper.cs
@@ -36,7 +36,7 @@ namespace Mono.TextTemplating.CodeCompilation
 				&& ProcessArgumentBuilder.TryParse (args, out var parsedArgs)
 				&& parsedArgs.Any (a => a.IndexOf("langversion") == 1);
 
-		static string ToString (CSharpLangVersion v) => v switch {
+		internal static string ToString (CSharpLangVersion v) => v switch {
 			CSharpLangVersion.v5_0 => "5",
 			CSharpLangVersion.v6_0 => "6",
 			CSharpLangVersion.v7_0 => "7",

--- a/Mono.TextTemplating/Mono.TextTemplating.CodeCompilation/RuntimeInfo.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating.CodeCompilation/RuntimeInfo.cs
@@ -142,12 +142,7 @@ namespace Mono.TextTemplating.CodeCompilation
 				return FromError (RuntimeKind.NetCore, "Could not find csc.dll in any .NET Core SDK");
 			}
 			string cscPath = sdkDir == null ? null : MakeCscPath (sdkDir);
-			CSharpLangVersion maxCSharpVersion;
-			if (sdkVersion.Equals(SemVersion.Zero) && DefaultMaxSupportedLangVersion.HasValue) {
-				maxCSharpVersion = DefaultMaxSupportedLangVersion.Value;
-			} else {
-				maxCSharpVersion = CSharpLangVersionHelper.FromNetCoreSdkVersion (sdkVersion);
-			}
+			CSharpLangVersion maxCSharpVersion = CSharpLangVersionHelper.FromNetCoreSdkVersion (sdkVersion);
 
 			// it's ok if this is null, we may be running on an older SDK that didn't support packs
 			//in which case we fall back to resolving from the runtime dir

--- a/Mono.TextTemplating/Mono.TextTemplating.CodeCompilation/RuntimeInfo.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating.CodeCompilation/RuntimeInfo.cs
@@ -57,7 +57,6 @@ namespace Mono.TextTemplating.CodeCompilation
 		public string RuntimeFacadesDir { get; internal set; }
 
 		internal static bool ThrowOnMissingDotNetCoreSdkDirectory { get; set; } = true;
-		internal static CSharpLangVersion? DefaultMaxSupportedLangVersion { get; set; }
 
 		public static RuntimeInfo GetRuntime ()
 		{


### PR DESCRIPTION
Not sure if this the best approach. I tried to minimise the changes needed to get t4 templating working in VS Mac 17.x

 - VS Mac bundles its own dotnet runtime which was causing problems for the RuntimeInfo class since there is no sdk available.
   - Allow the sdk to be missing when using the Roslyn code compiler.
 - Ensure best C# language version is used when the Roslyn code compiler is used.

 