### PR TITLE
TemplatingEngine: Move from using Path.GetTempFileName to a Guid

### DIFF
--- a/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
@@ -302,12 +302,7 @@ namespace Mono.TextTemplating
 			// this may throw, so do it before writing source files
 			var compiler = GetOrCreateCompiler ();
 
-			// GetTempFileName guarantees that the returned file name is unique, but
-			// there are no equivalent for directories, so we create a directory
-			// based on the file name, which *should* be unique as long as the file
-			// exists.
-			var tempFile = Path.GetTempFileName ();
-			var tempFolder = tempFile + "dir";
+			var tempFolder = string.Concat (Path.GetTempPath (), "t4-", Guid.NewGuid ().ToString ("N"));
 			Directory.CreateDirectory (tempFolder);
 
 			if (settings.Log != null) {
@@ -370,7 +365,6 @@ namespace Mono.TextTemplating
 				r.TempFiles.Delete ();
 				// we can delete our temporary file after our temporary folder is deleted.
 				Directory.Delete (tempFolder);
-				File.Delete (tempFile);
 			}
 
 			return (r, compiledAssembly);


### PR DESCRIPTION
Path.GetTempFileName is prone to failures on Windows (https://learn.microsoft.com/en-us/dotnet/api/system.io.path.gettempfilename?view=net-7.0#remarks)