### PR TITLE
Exposes the generator's UseRelativeLinePragmas option in the CLI tool.

### DIFF
--- a/dotnet-t4/TextTransform.cs
+++ b/dotnet-t4/TextTransform.cs
@@ -104,6 +104,11 @@ namespace Mono.TextTemplating
 					(s) => preprocessClassName = s
 				},
 				{
+					"l|useRelativeLinePragmas",
+					"Use relative paths in line pragmas.",
+					s => generator.UseRelativeLinePragmas = true
+				},
+				{
 					"p==|parameter==",
 					"Set session parameter {0:<name>} to {1:<value>}. " +
 					"The value is accessed from the template's Session dictionary, " +

--- a/dotnet-t4/readme.md
+++ b/dotnet-t4/readme.md
@@ -61,6 +61,7 @@ Option | Description
 `-I=<directory>` | Add a `<directory>` to be searched when resolving included files
 `-P=<directory>` | Add a `<directory>` to be searched when resolving assemblies.
 `-c`<br/>`--class=<name>` | Preprocess the template into class `<name>` for use as a runtime template. The class name may include a namespace.
+`-l`<br/>`--useRelativeLinePragmas` | Use relative paths in line pragmas.
 `-p`, `--parameter=<name>=<value>` |  Set session parameter `<name>` to `<value>`. The value is accessed from the template's `Session` dictionary, or from a property declared with a parameter directive: `<#@ parameter name='<name>' type='<type>' #>.` <br/> If the `<name>` matches a parameter with a non-string type, the `<value>` will be converted to that type.
 `--debug` | Generate debug symbols and keep temporary files.
 `-v` <br/> `--verbose` | Output additional diagnostic information to stdout.


### PR DESCRIPTION
Added an option to expose the underlying `UseRelativeLinePragmas` option on the generator.

This enables us to (optionally) restore what was the default behaviour prior to v2.3.0.

This commit resolves #152 