### PR TITLE
Remove unsupported TFMs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -78,6 +78,10 @@ csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
 dotnet_style_require_accessibility_modifiers = omit_if_default:warning
+
+# ArgumentNullException.ThrowIfNull not present in some TFMs
+dotnet_diagnostic.CA1510.severity = none
+
 # hack: suppress analyzers on the imported file Options.cs
 [Options.cs]
 generated_code = true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,8 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: |
-          2.1.x
-          3.1.x
-          5.0.x
           6.0.x
+          7.0.x
 
     - name: Find MSBuild
       if: startsWith(matrix.os, 'windows')

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- reproducible build -->
@@ -29,7 +29,7 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 
   <PropertyGroup>

--- a/Mono.TextTemplating.Build.Tests/MSBuildExecutionTests.cs
+++ b/Mono.TextTemplating.Build.Tests/MSBuildExecutionTests.cs
@@ -9,6 +9,8 @@ using Xunit;
 
 namespace Mono.TextTemplating.Tests
 {
+	// MSBuild relies on changing the current working directory to the project directory so we need to run tests serially
+	[CollectionDefinition (nameof (MSBuildExecutionTests), DisableParallelization = true)]
 	public class MSBuildExecutionTests : IClassFixture<MSBuildFixture>
 	{
 		[Fact]

--- a/Mono.TextTemplating.Build.Tests/MSBuildTestContext.cs
+++ b/Mono.TextTemplating.Build.Tests/MSBuildTestContext.cs
@@ -45,7 +45,7 @@ namespace Mono.TextTemplating.Tests
 
 		public ProjectCollection Engine { get; }
 
-		static ILogger CreateBinLogger (string testName) => new BinaryLogger { Parameters = $"LogFile=binlogs/{testName}.binlog" };
+		static BinaryLogger CreateBinLogger (string testName) => new BinaryLogger { Parameters = $"LogFile=binlogs/{testName}.binlog" };
 
 		public void Dispose ()
 		{
@@ -71,7 +71,7 @@ namespace Mono.TextTemplating.Tests
 		}
 	}
 
-	class MSBuildTestProject
+	sealed class MSBuildTestProject
 	{
 		public MSBuildTestProject (MSBuildTestContext context, Project project)
 		{
@@ -125,7 +125,7 @@ namespace Mono.TextTemplating.Tests
 		}
 	}
 
-	class MSBuildTestErrorLogger : ILogger
+	sealed class MSBuildTestErrorLogger : ILogger
 	{
 		public List<BuildEventArgs> ErrorsAndWarnings { get; } = new List<BuildEventArgs> ();
 
@@ -232,7 +232,7 @@ namespace Mono.TextTemplating.Tests
 			=> GetIntermediateDir (instance).Combine (paths);
 	}
 
-	class MSBuildFixture
+	sealed class MSBuildFixture
 	{
 		public MSBuildFixture () => MSBuildTestHelpers.RegisterMSBuildAssemblies ();
 	}

--- a/Mono.TextTemplating.Build.Tests/MSBuildTestContext.cs
+++ b/Mono.TextTemplating.Build.Tests/MSBuildTestContext.cs
@@ -188,7 +188,7 @@ namespace Mono.TextTemplating.Tests
 			var actualPaths = items.Select (item => item.GetMetadataValue ("FullPath")).ToHashSet ();
 			foreach (var expectedPath in expectedFullPaths) {
 				if (!actualPaths.Remove (expectedPath)) {
-					throw new Xunit.Sdk.ContainsException (expectedPath, actualPaths);
+					throw Xunit.Sdk.ContainsException.ForSetItemNotFound ("\"" + expectedPath + "\"", "\"" + string.Join ("\", \"", actualPaths) + "\"");
 				}
 			}
 			Assert.Empty (actualPaths);

--- a/Mono.TextTemplating.Build.Tests/MSBuildTestHelpers.cs
+++ b/Mono.TextTemplating.Build.Tests/MSBuildTestHelpers.cs
@@ -41,7 +41,9 @@ namespace Mono.TextTemplating.Tests
 				//attempt to read the msbuild.dll location from the launch script
 				//FIXME: handle quoting in the script
 				Console.WriteLine ("Found msbuild script in PATH: {0}", msbuildInPath);
+#pragma warning disable CA1861 // Avoid constant arrays as arguments
 				var tokens = File.ReadAllText (msbuildInPath).Split (new [] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+#pragma warning restore CA1861 // Avoid constant arrays as arguments
 				var filename = tokens.FirstOrDefault (t => t.EndsWith ("MSBuild.dll", StringComparison.OrdinalIgnoreCase));
 				if (filename != null && File.Exists (filename)) {
 					var dir = Path.GetDirectoryName (filename);

--- a/Mono.TextTemplating.Build.Tests/Mono.TextTemplating.Build.Tests.csproj
+++ b/Mono.TextTemplating.Build.Tests/Mono.TextTemplating.Build.Tests.csproj
@@ -10,26 +10,25 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
-    <PackageReference Include="Microsoft.Build" Version="17.3.1" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.3.1" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.1" ExcludeAssets="runtime" />
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version ="6.0.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
+    <PackageReference Include="Microsoft.Build" Version="17.3.2" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.3.2" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.2" ExcludeAssets="runtime" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
     <!--
     Microsoft.NET.Test.Sdk brings in a version of NuGet.Frameworks that's older than the one used by MSBuild
     and loads first, thereby breaking loading of MSBuild assemblies. Force-upgrade it.
     -->
-    <PackageReference Include="NuGet.Frameworks" Version="6.4.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.6" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.7.0" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <!-- newer versions drop netcoreapp2.1 -->
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
     <!-- seems to be required for tests to run on Mono -->
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.3.2" Condition="'$(TargetFramework)'=='net472' And $([MSBuild]::IsOSUnixLike())" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.7.2" Condition="'$(TargetFramework)'=='net472' And $([MSBuild]::IsOSUnixLike())" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mono.TextTemplating.Build.Tests/Mono.TextTemplating.Build.Tests.csproj
+++ b/Mono.TextTemplating.Build.Tests/Mono.TextTemplating.Build.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestCases\**</DefaultItemExcludes>
   </PropertyGroup>
@@ -19,7 +19,7 @@
     Microsoft.NET.Test.Sdk brings in a version of NuGet.Frameworks that's older than the one used by MSBuild
     and loads first, thereby breaking loading of MSBuild assemblies. Force-upgrade it.
     -->
-    <PackageReference Include="NuGet.Frameworks" Version="6.3.1" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.4.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.6" />
   </ItemGroup>
 

--- a/Mono.TextTemplating.Build.Tests/Mono.TextTemplating.Build.Tests.csproj
+++ b/Mono.TextTemplating.Build.Tests/Mono.TextTemplating.Build.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net48;$(TargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestCases\**</DefaultItemExcludes>
   </PropertyGroup>
@@ -27,14 +28,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="xunit" Version="2.5.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
-    <!-- seems to be required for tests to run on Mono -->
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.7.2" Condition="'$(TargetFramework)'=='net472' And $([MSBuild]::IsOSUnixLike())" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="TestCases\**\*.*" />
-    <!-- disable parallel test execution on github actions, it hangs the runner there -->
-    <None Include="..\Mono.TextTemplating.Tests\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" Condition="'$(GITHUB_ACTIONS)'=='true'" />
     <Compile Include="..\Mono.TextTemplating.Tests\Platform.cs" />
     <Compile Include="..\Mono.TextTemplating.Tests\TestDataPath.cs" />
   </ItemGroup>

--- a/Mono.TextTemplating.Build/MSBuildTemplateGenerator.cs
+++ b/Mono.TextTemplating.Build/MSBuildTemplateGenerator.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.TextTemplating;
 
 namespace Mono.TextTemplating.Build
 {
-	class MSBuildTemplateGenerator : TemplateGenerator
+	sealed class MSBuildTemplateGenerator : TemplateGenerator
 	{
 		public MSBuildTemplateGenerator ()
 		{

--- a/Mono.TextTemplating.Build/MSBuildTemplateSession.cs
+++ b/Mono.TextTemplating.Build/MSBuildTemplateSession.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.TextTemplating;
 
 namespace Mono.TextTemplating.Build
 {
-	class MSBuildTemplateSession : ITextTemplatingSession
+	sealed class MSBuildTemplateSession : ITextTemplatingSession
 	{
 		readonly Dictionary<string, object> session = new Dictionary<string, object> ();
 		readonly MSBuildTemplateGenerator toolTemplateGenerator;

--- a/Mono.TextTemplating.Build/Mono.TextTemplating.Build.csproj
+++ b/Mono.TextTemplating.Build/Mono.TextTemplating.Build.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <PackageId>T4.BuildTools</PackageId>
     <Description>MSBuild build targets for the T4 templating language, a general-purpose way to generate text or code files using C#</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Mono.TextTemplating.Build/Mono.TextTemplating.Build.csproj
+++ b/Mono.TextTemplating.Build/Mono.TextTemplating.Build.csproj
@@ -10,6 +10,7 @@
          end up loading Mono.TextTemplating.dll for the wrong runtime -->
     <BuildOutputTargetFolder>buildTasks</BuildOutputTargetFolder>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
 
   <Target Name="AddTargetsFilesToPack" BeforeTargets="GenerateNuspec">

--- a/Mono.TextTemplating.Build/Mono.TextTemplating.Build.csproj
+++ b/Mono.TextTemplating.Build/Mono.TextTemplating.Build.csproj
@@ -30,11 +30,12 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="MessagePackAnalyzer" Version="2.2.85" PrivateAssets="all" />
-    <PackageReference Include="MessagePack" Version="2.2.85" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.1.548" PrivateAssets="all" IncludeAssets="compile" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.548" PrivateAssets="all" IncludeAssets="compile" />
     <ProjectReference Include="..\Mono.TextTemplating\Mono.TextTemplating.csproj" PrivateAssets="all" />
+    <PackageReference Include="MessagePackAnalyzer" Version="2.5.129" PrivateAssets="all" />
+    <PackageReference Include="MessagePack" Version="2.5.129" PrivateAssets="all" />
+    <!-- intentionally downlevel these so they can be loaded in older VS versions -->
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" PrivateAssets="all" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="all" IncludeAssets="compile" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mono.TextTemplating.Build/TemplateBuildState.cs
+++ b/Mono.TextTemplating.Build/TemplateBuildState.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 using MessagePack;
@@ -16,10 +17,10 @@ namespace Mono.TextTemplating.Build
 	[MessagePackObject]
 	public class TemplateBuildState
 	{
-		public const int CURRENT_FORMAT_VERSION = 0;
+		public const int CurrentFormatVersion = 0;
 
 		[Key (0)]
-		public int FormatVersion { get; set; } = CURRENT_FORMAT_VERSION;
+		public int FormatVersion { get; set; } = CurrentFormatVersion;
 		[Key (1)]
 		public string DefaultNamespace { get; set; }
 		[Key (2)]
@@ -185,6 +186,8 @@ namespace Mono.TextTemplating.Build
 				=> Name == other?.Name && Class == other.Name && Assembly == other?.Assembly;
 
 			public override bool Equals (object obj) => Equals (obj as DirectiveProcessor);
+
+			public override int GetHashCode () => HashCode.Combine (Name, Class, Assembly);
 		}
 
 		[MessagePackObject]
@@ -203,6 +206,8 @@ namespace Mono.TextTemplating.Build
 				=> Processor == other?.Processor && Directive == other.Directive && Name == other?.Name && Value == other?.Value;
 
 			public override bool Equals (object obj) => Equals (obj as Parameter);
+
+			public override int GetHashCode () => HashCode.Combine (Processor, Directive, Name, Value);
 		}
 
 		// TODO: cache warnings
@@ -280,5 +285,13 @@ namespace Mono.TextTemplating.Build
 				return false;
 			}
 		}
+
+#if !NETCOREAPP2_1_OR_GREATER
+		struct HashCode
+		{
+			public static int Combine<T1, T2, T3> (T1 value1, T2 value2, T3 value3) => (value1?.GetHashCode () ?? 0) ^ (value2?.GetHashCode () ?? 0) ^ (value3?.GetHashCode () ?? 0);
+			public static int Combine<T1, T2, T3, T4> (T1 value1, T2 value2, T3 value3, T4 value4) => Combine (value1, value2, value3) ^ (value4?.GetHashCode () ?? 0);
+		}
+#endif
 	}
 }

--- a/Mono.TextTemplating.Build/TextTransform.cs
+++ b/Mono.TextTemplating.Build/TextTransform.cs
@@ -260,7 +260,7 @@ namespace Mono.TextTemplating.Build
 
 				var state =  MessagePackSerializer.Deserialize<TemplateBuildState> (stream, options);
 
-				if (state.FormatVersion != TemplateBuildState.CURRENT_FORMAT_VERSION) {
+				if (state.FormatVersion != TemplateBuildState.CurrentFormatVersion) {
 					Log.LogMessageFromResources (MessageImportance.Low, nameof(Messages.BuildStateFormatChanged));
 				}
 

--- a/Mono.TextTemplating.Build/TextTransformProcessor.cs
+++ b/Mono.TextTemplating.Build/TextTransformProcessor.cs
@@ -209,7 +209,7 @@ namespace Mono.TextTemplating.Build
 			return generator;
 		}
 
-		class WriteTimeCache
+		sealed class WriteTimeCache
 		{
 			public DateTime? GetWriteTime (string filepath)
 			{

--- a/Mono.TextTemplating.Roslyn/Mono.TextTemplating.Roslyn.csproj
+++ b/Mono.TextTemplating.Roslyn/Mono.TextTemplating.Roslyn.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
-    <None Include="readme.md" Pack="true" PackagePath="\"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
+    <None Include="readme.md" Pack="true" PackagePath="\" />
     <ProjectReference Include="..\Mono.TextTemplating\Mono.TextTemplating.csproj" />
   </ItemGroup>
 </Project>

--- a/Mono.TextTemplating.Roslyn/Mono.TextTemplating.Roslyn.csproj
+++ b/Mono.TextTemplating.Roslyn/Mono.TextTemplating.Roslyn.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net6.0</TargetFrameworks>
     <PackageId>Mono.TextTemplating.Roslyn</PackageId>
     <DefaultNamespace>Mono.TextTemplating</DefaultNamespace>
     <Description>In-process Roslyn compiler for the Mono.TextTemplating T4 templating engine</Description>

--- a/Mono.TextTemplating.Roslyn/RoslynCodeCompiler.cs
+++ b/Mono.TextTemplating.Roslyn/RoslynCodeCompiler.cs
@@ -17,7 +17,7 @@ using CodeCompiler = Mono.TextTemplating.CodeCompilation.CodeCompiler;
 
 namespace Mono.TextTemplating
 {
-	class RoslynCodeCompiler : CodeCompiler
+	sealed class RoslynCodeCompiler : CodeCompiler
 	{
 		readonly RuntimeInfo runtime;
 

--- a/Mono.TextTemplating.Roslyn/RoslynCodeCompilerException.cs
+++ b/Mono.TextTemplating.Roslyn/RoslynCodeCompilerException.cs
@@ -1,16 +1,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Runtime.Serialization;
 
 namespace Mono.TextTemplating
 {
 	[Serializable]
-	class RoslynCodeCompilerException : Exception
+	sealed class RoslynCodeCompilerException : Exception
 	{
 		public RoslynCodeCompilerException () { }
 		public RoslynCodeCompilerException (string message) : base (message) { }
 		public RoslynCodeCompilerException (string message, Exception inner) : base (message, inner) { }
-		protected RoslynCodeCompilerException (SerializationInfo info, StreamingContext context) : base (info, context) { }
 	}
 }

--- a/Mono.TextTemplating.Tests/AppDomainTests.cs
+++ b/Mono.TextTemplating.Tests/AppDomainTests.cs
@@ -107,7 +107,7 @@ public class AppDomainTests : AssemblyLoadTests<SnapshotSet<string>>
 
 	static string GetAppDomainNameForCurrentTest ([CallerMemberName] string testName = null) => $"Template Test - {testName ?? "(unknown)"}";
 
-	class TestTemplateGeneratorWithAppDomain : TemplateGenerator
+	sealed class TestTemplateGeneratorWithAppDomain : TemplateGenerator
 	{
 		AppDomain appDomain;
 		public TestTemplateGeneratorWithAppDomain (AppDomain appDomain) => this.appDomain = appDomain;

--- a/Mono.TextTemplating.Tests/GenerateIndentedClassCodeTests.cs
+++ b/Mono.TextTemplating.Tests/GenerateIndentedClassCodeTests.cs
@@ -49,13 +49,13 @@ namespace Mono.TextTemplating.Tests
 			Assert.Equal (expectedOutput, output);
 		}
 
-		static CodeTypeMember CreateBoolField ()
+		static CodeMemberField CreateBoolField ()
 		{
 			var type = new CodeTypeReference (typeof(bool));
 			return new CodeMemberField { Name = "myField", Type = type };
 		}
 
-		static CodeTypeMember CreateBoolProperty ()
+		static CodeMemberProperty CreateBoolProperty ()
 		{
 			var type = new CodeTypeReference (typeof(bool));
 			var prop = new CodeMemberProperty { Name = "MyProperty", Type = type };

--- a/Mono.TextTemplating.Tests/GenerationTests.cs
+++ b/Mono.TextTemplating.Tests/GenerationTests.cs
@@ -89,7 +89,7 @@ namespace Mono.TextTemplating.Tests
 
 		#region Helpers
 
-		static string GenerateCode (ITextTemplatingEngineHost host, string content, string name, string generatorNewline)
+		static string GenerateCode (DummyHost host, string content, string name, string generatorNewline)
 		{
 			var pt = ParsedTemplate.FromTextInternal (content, host);
 			if (pt.Errors.HasErrors) {

--- a/Mono.TextTemplating.Tests/Mono.TextTemplating.Tests.csproj
+++ b/Mono.TextTemplating.Tests/Mono.TextTemplating.Tests.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Mono.TextTemplating.Build\Mono.TextTemplating.Build.csproj" />
     <ProjectReference Include="..\Mono.TextTemplating\Mono.TextTemplating.csproj" />
     <ProjectReference Include="..\Mono.TextTemplating.Roslyn\Mono.TextTemplating.Roslyn.csproj" />
   </ItemGroup>
@@ -18,12 +17,11 @@
     -->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <!-- newer versions drop netcoreapp2.1 -->
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
     <!-- seems to be required for tests to run on Mono -->
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.3.2" Condition="'$(TargetFramework)'=='net472' And $([MSBuild]::IsOSUnixLike())" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.7.2" Condition="'$(TargetFramework)'=='net472' And $([MSBuild]::IsOSUnixLike())" />
   </ItemGroup>
 
   <ItemGroup>
@@ -49,11 +47,7 @@
       <!-- temp vars to make escaping manageable -->
       <_PackageDownloadWithVersion Include="@(PackageDownload)" Version="$([System.String]::Copy('%(Version)').Replace('[','').Replace(']',''))" />
       <_PackageDownloadWithPath Include="@(_PackageDownloadWithVersion)" Path="$(_NuGetPackageRootWithTrailingSlash)$([System.String]::Copy('%(Identity)').ToLower())\%(Version)" />
-      <_PackageDownloadVars
-        Include="@(_PackageDownloadWithPath)"
-        VarName="$([System.String]::Copy('%(Identity)_%(Version)').Replace('.','_'))"
-        EscapedValue="$([System.String]::Copy('%(Path)').Replace('\','\\'))"
-      />
+      <_PackageDownloadVars Include="@(_PackageDownloadWithPath)" VarName="$([System.String]::Copy('%(Identity)_%(Version)').Replace('.','_'))" EscapedValue="$([System.String]::Copy('%(Path)').Replace('\','\\'))" />
       <_PackageDownloadPathConstLines Include="namespace $(ProjectName) {" />
       <_PackageDownloadPathConstLines Include="sealed class PackagePath {" />
       <_PackageDownloadPathConstLines Include="@(_PackageDownloadVars->'    public static TestDataPath %(VarName) =&gt; new(&quot;%(EscapedValue)&quot;);')" />

--- a/Mono.TextTemplating.Tests/Mono.TextTemplating.Tests.csproj
+++ b/Mono.TextTemplating.Tests/Mono.TextTemplating.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DefineConstants Condition="'$(TargetFramework)'=='net472'">$(DefineConstants);FEATURE_APPDOMAINS</DefineConstants>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestCases\**</DefaultItemExcludes>

--- a/Mono.TextTemplating.Tests/Mono.TextTemplating.Tests.csproj
+++ b/Mono.TextTemplating.Tests/Mono.TextTemplating.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net472;$(TargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DefineConstants Condition="'$(TargetFramework)'=='net472'">$(DefineConstants);FEATURE_APPDOMAINS</DefineConstants>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestCases\**</DefaultItemExcludes>
@@ -10,24 +11,15 @@
     <ProjectReference Include="..\Mono.TextTemplating\Mono.TextTemplating.csproj" />
     <ProjectReference Include="..\Mono.TextTemplating.Roslyn\Mono.TextTemplating.Roslyn.csproj" />
   </ItemGroup>
-    <!-- fix conflicts in indirect references
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" PrivateAssets="all" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    -->
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="xunit" Version="2.5.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
-    <!-- seems to be required for tests to run on Mono -->
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.7.2" Condition="'$(TargetFramework)'=='net472' And $([MSBuild]::IsOSUnixLike())" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="TestCases\**\*.*" />
-    <!-- disable parallel test execution on github actions, it hangs the runner there -->
-    <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" Condition="'$(GITHUB_ACTIONS)'=='true'" />
   </ItemGroup>
 
   <!-- download packages that contains dlls referenced by test tt files -->

--- a/Mono.TextTemplating.Tests/Mono.TextTemplating.Tests.csproj
+++ b/Mono.TextTemplating.Tests/Mono.TextTemplating.Tests.csproj
@@ -55,7 +55,7 @@
         EscapedValue="$([System.String]::Copy('%(Path)').Replace('\','\\'))"
       />
       <_PackageDownloadPathConstLines Include="namespace $(ProjectName) {" />
-      <_PackageDownloadPathConstLines Include="partial class PackagePath {" />
+      <_PackageDownloadPathConstLines Include="sealed class PackagePath {" />
       <_PackageDownloadPathConstLines Include="@(_PackageDownloadVars->'    public static TestDataPath %(VarName) =&gt; new(&quot;%(EscapedValue)&quot;);')" />
       <_PackageDownloadPathConstLines Include="}}" />
     </ItemGroup>

--- a/Mono.TextTemplating.Tests/ProcessingTests.cs
+++ b/Mono.TextTemplating.Tests/ProcessingTests.cs
@@ -57,10 +57,13 @@ namespace Mono.TextTemplating.Tests
 			await gen.ProcessTemplateAsync (null, template, outputName);
 
 			CompilerError firstError = gen.Errors.OfType<CompilerError> ().FirstOrDefault ();
-#if NET5_0
-			Assert.Null (firstError);
-#else
+
+			// note: when running on netsdk we use the highest available csc regardless of runtime version,
+			// so records will always be available on our test environments
+#if NETFRAMEWORK
 			Assert.NotNull (firstError);
+#else
+			Assert.Null (firstError);
 #endif
 		}
 

--- a/Mono.TextTemplating.Tests/TestDataPath.cs
+++ b/Mono.TextTemplating.Tests/TestDataPath.cs
@@ -147,7 +147,7 @@ struct TestDataPath
 	}
 }
 
-class WriteTimeTracker
+sealed class WriteTimeTracker
 {
 	readonly TestDataPath file;
 	DateTime lastWriteTime;

--- a/Mono.TextTemplating.Tests/xunit.runner.json
+++ b/Mono.TextTemplating.Tests/xunit.runner.json
@@ -1,4 +1,0 @@
-{
-    "parallelizeAssembly": false,
-    "parallelizeTestCollections": false
-}

--- a/Mono.TextTemplating.sln
+++ b/Mono.TextTemplating.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30914.41
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34004.107
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mono.TextTemplating", "Mono.TextTemplating\Mono.TextTemplating.csproj", "{A2364D6A-00EF-417C-80A6-815726C70032}"
 EndProject
@@ -16,8 +16,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-t4", "dotnet-t4\dotnet-t4.csproj", "{6AA924D8-7119-4593-9B56-11D17AC3578E}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-t4-project-tool", "dotnet-t4-project-tool\dotnet-t4-project-tool.csproj", "{114B7AEF-61DA-453A-9A84-6DDEA13460B7}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mono.TextTemplating.Build", "Mono.TextTemplating.Build\Mono.TextTemplating.Build.csproj", "{12F53C72-56EC-4740-B6B2-FF31A1B3D3B8}"
 EndProject
@@ -47,10 +45,6 @@ Global
 		{6AA924D8-7119-4593-9B56-11D17AC3578E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6AA924D8-7119-4593-9B56-11D17AC3578E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6AA924D8-7119-4593-9B56-11D17AC3578E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{114B7AEF-61DA-453A-9A84-6DDEA13460B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{114B7AEF-61DA-453A-9A84-6DDEA13460B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{114B7AEF-61DA-453A-9A84-6DDEA13460B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{114B7AEF-61DA-453A-9A84-6DDEA13460B7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{12F53C72-56EC-4740-B6B2-FF31A1B3D3B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{12F53C72-56EC-4740-B6B2-FF31A1B3D3B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{12F53C72-56EC-4740-B6B2-FF31A1B3D3B8}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/Mono.TextTemplating/CompatibilitySuppressions.xml
+++ b/Mono.TextTemplating/CompatibilitySuppressions.xml
@@ -1,9 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Suppressions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- fixes binary incompatibility between multitargeted versions -->
   <Suppression>
-    <!-- fixes binary incompatibility between multitargeted versions -->
     <DiagnosticId>CP0006</DiagnosticId>
     <Target>M:Microsoft.VisualStudio.TextTemplating.ITextTemplatingEngineHost.ProvideTemplatingAppDomain(System.String)</Target>
+    <Left>lib/netstandard2.0/Mono.TextTemplating.dll</Left>
+    <Right>lib/netstandard2.0/Mono.TextTemplating.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+    <!-- VST4 compat, should not have been public, unlikely to impact users -->
+  <Suppression>
+    <DiagnosticId>CP0019</DiagnosticId>
+    <Target>M:Microsoft.VisualStudio.TextTemplating.DirectiveProcessorException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</Target>
+    <Left>lib/net472/Mono.TextTemplating.dll</Left>
+    <Right>lib/net472/Mono.TextTemplating.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0019</DiagnosticId>
+    <Target>M:Microsoft.VisualStudio.TextTemplating.DirectiveProcessorException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</Target>
     <Left>lib/netstandard2.0/Mono.TextTemplating.dll</Left>
     <Right>lib/netstandard2.0/Mono.TextTemplating.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/Mono.TextTemplating/Mono.TextTemplating.csproj
+++ b/Mono.TextTemplating/Mono.TextTemplating.csproj
@@ -19,7 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CodeDom" Version="5.0.0" Condition="'$(TargetFramework)'!='net472'" />
+    <!-- limit to 6.0 so that the MSBuild task can load on .NET 6.0 -->
+    <PackageReference Include="System.CodeDom" Version="6.0.0" Condition="'$(TargetFramework)'!='net472'" />
     <None Include="readme.md" Pack="true" PackagePath="\" />
     <None Include="package\Mono.TextTemplating.targets" Pack="true" PackagePath="buildTransitive\net461\Mono.TextTemplating.targets" />
     <None Include="package\Mono.TextTemplating.targets" Pack="true" PackagePath="buildTransitive\net472\_._" />

--- a/Mono.TextTemplating/Mono.TextTemplating.csproj
+++ b/Mono.TextTemplating/Mono.TextTemplating.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net472</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>1591;1573</NoWarn>
     <TFxId>$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)'))</TFxId>
@@ -21,6 +21,10 @@
   <ItemGroup>
     <PackageReference Include="System.CodeDom" Version="5.0.0" Condition="'$(TargetFramework)'!='net472'" />
     <None Include="readme.md" Pack="true" PackagePath="\" />
+    <None Include="package\Mono.TextTemplating.targets" Pack="true" PackagePath="buildTransitive\net461\Mono.TextTemplating.targets" />
+    <None Include="package\Mono.TextTemplating.targets" Pack="true" PackagePath="buildTransitive\net472\_._" />
+    <None Include="package\Mono.TextTemplating.targets" Pack="true" PackagePath="buildTransitive\netcoreapp2.0\Mono.TextTemplating.targets" />
+    <None Include="package\Mono.TextTemplating.targets" Pack="true" PackagePath="buildTransitive\net6.0\_._" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mono.TextTemplating/Mono.TextTemplating.csproj
+++ b/Mono.TextTemplating/Mono.TextTemplating.csproj
@@ -15,11 +15,12 @@
     <Description>Embeddable engine for the T4 templating language, a general-purpose way to generate text or code files using C#</Description>
     <PackageValidationBaselineVersion>2.2.1</PackageValidationBaselineVersion>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.CodeDom" Version="5.0.0" Condition="'$(TargetFramework)'!='net472'" />
-    <None Include="readme.md" Pack="true" PackagePath="\"/>
+    <None Include="readme.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
@@ -388,7 +388,7 @@ namespace Mono.TextTemplating
 			processor = directive = name = value = "";
 
 			int start = 0;
-			int end = parameter.IndexOfAny (new [] { '=', '!' });
+			int end = parameter.IndexOfAny (parameterInitialSplitChars);
 			if (end < 0)
 				return false;
 
@@ -572,6 +572,8 @@ namespace Mono.TextTemplating
 		/// If non-null, the template's Host property will be the full type of this host.
 		/// </summary>
 		public virtual Type SpecificHostType { get { return null; } }
+
+		static readonly char[] parameterInitialSplitChars = new [] { '=', '!' };
 
 		/// <summary>
 		/// Gets any additional directive processors to be included in the processing run.

--- a/Mono.TextTemplating/package/Mono.TextTemplating.targets
+++ b/Mono.TextTemplating/package/Mono.TextTemplating.targets
@@ -1,0 +1,6 @@
+<Project InitialTargets="NETStandardCompatError_Mono_TextTemplating_net6_0">
+  <Target Name="NETStandardCompatError_Mono_TextTemplating_net6_0"
+          Condition="'$(SuppressTfmSupportBuildWarnings)' == ''">
+    <Warning Text="Mono_TextTemplating doesn't support $(TargetFramework) and has not been tested with it. Consider upgrading your TargetFramework to net6.0 or later. You may also set &lt;SuppressTfmSupportBuildWarnings&gt;true&lt;/SuppressTfmSupportBuildWarnings&gt; in the project file to ignore this warning and attempt to run in this unsupported configuration at your own risk." />
+  </Target>
+</Project>

--- a/TextTransform/Options.cs
+++ b/TextTransform/Options.cs
@@ -756,7 +756,9 @@ namespace Mono.Options
 
 #if !PCL
 #pragma warning disable 618 // SecurityPermissionAttribute is obsolete
+#pragma warning disable SYSLIB0003 // Type or member is obsolete
 		[SecurityPermission (SecurityAction.LinkDemand, SerializationFormatter = true)]
+#pragma warning restore SYSLIB0003
 #pragma warning restore 618
 		public override void GetObjectData (SerializationInfo info, StreamingContext context)
 		{

--- a/TextTransform/TextTransform.cs
+++ b/TextTransform/TextTransform.cs
@@ -32,7 +32,7 @@ using Mono.Options;
 
 namespace Mono.TextTemplating
 {
-	class TextTransform
+	sealed class TextTransform
 	{
 		static OptionSet optionSet;
 

--- a/dotnet-t4/TextTransform.cs
+++ b/dotnet-t4/TextTransform.cs
@@ -32,7 +32,7 @@ using Mono.Options;
 
 namespace Mono.TextTemplating
 {
-	class TextTransform
+	sealed class TextTransform
 	{
 		static OptionSet optionSet;
 

--- a/dotnet-t4/ToolTemplateGenerator.cs
+++ b/dotnet-t4/ToolTemplateGenerator.cs
@@ -25,7 +25,7 @@ using Microsoft.VisualStudio.TextTemplating;
 
 namespace Mono.TextTemplating
 {
-	class ToolTemplateGenerator : TemplateGenerator
+	sealed class ToolTemplateGenerator : TemplateGenerator
 	{
 		public ToolTemplateGenerator ()
 		{

--- a/dotnet-t4/ToolTemplateSession.cs
+++ b/dotnet-t4/ToolTemplateSession.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) Microsoft Corp (https://www.microsoft.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -27,7 +27,7 @@ using System.Runtime.Serialization;
 
 namespace Mono.TextTemplating
 {
-	class ToolTemplateSession : ITextTemplatingSession
+	sealed class ToolTemplateSession : ITextTemplatingSession
 	{
 		readonly Dictionary<string, object> session = new Dictionary<string, object> ();
 		readonly ToolTemplateGenerator toolTemplateGenerator;

--- a/dotnet-t4/dotnet-t4.csproj
+++ b/dotnet-t4/dotnet-t4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>t4</AssemblyName>
     <PackageId>dotnet-t4</PackageId>
     <RollForward>LatestMajor</RollForward>
@@ -21,6 +21,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Mono.TextTemplating\Mono.TextTemplating.csproj" />
     <Compile Include="..\TextTransform\Options.cs" Link="Options.cs" />
-    <None Include="readme.md" Pack="true" PackagePath="\"/>
+    <None Include="readme.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.4.0-preview.{height}",
+  "version": "3.0.0-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/tags/v\\d+\\.\\d+$",
     "^refs/tags/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
Remove support for out-of-support .NET versions as they massively complicate testing the library and have stalled development