### PR TITLE
Don't use AppDomain codepath for CurrentDomain

### DIFF
--- a/Mono.TextTemplating/Mono.TextTemplating/CompiledTemplate.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/CompiledTemplate.cs
@@ -82,7 +82,10 @@ namespace Mono.TextTemplating
 		TemplateProcessor CreateTemplateProcessor ()
 		{
 			var domain = host.ProvideTemplatingAppDomain (templateContentForAppDomain);
-			if (domain == null) {
+
+			// hosts are supposed to return null of they don't want to use a domain
+			// but check for CurrentDomain too so we can optimize if they do that
+			if (domain == null || domain == AppDomain.CurrentDomain) {
 				return new TemplateProcessor ();
 			}
 


### PR DESCRIPTION
Template hosts should return `null` from `ProvideTemplatingAppDomain` if they don't want to use an `AppDomain`, but check for `AppDomain.CurrentDomain` and shortcircuit that as well.

Improves usability issue discovered in #170